### PR TITLE
[ISSUE-1]: Add localization infrastructure

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier";
+import i18next from "eslint-plugin-i18next";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import globals from "globals";
@@ -19,6 +20,12 @@ export default defineConfig([
     ],
     languageOptions: {
       globals: globals.browser,
+    },
+    plugins: {
+      i18next,
+    },
+    rules: {
+      "i18next/no-literal-string": ["error", { mode: "jsx-only" }],
     },
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "scars-of-steel",
       "version": "0.0.0",
       "dependencies": {
+        "i18next": "^26.3.6",
         "react": "^19.2.8",
-        "react-dom": "^19.2.8"
+        "react-dom": "^19.2.8",
+        "react-i18next": "^17.0.11"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -21,6 +23,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-i18next": "^6.1.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
         "globals": "^17.11.0",
@@ -291,7 +294,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2026,6 +2028,19 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-i18next": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.5.tgz",
+      "integrity": "sha512-xCTfstbK9ZpQ6UFT5S1s6zbZMhKn2o2jRSQYiU2UkV7wt8y1m3WjkUYGkGlipgRdFInYI9+LAqE+JQU/L73HmA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=18.10.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -2341,6 +2356,43 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://locize.com"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -3149,6 +3201,33 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -3179,6 +3258,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/rolldown": {
@@ -3437,7 +3526,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3527,6 +3616,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "typecheck": "tsc -b --pretty false"
   },
   "dependencies": {
+    "i18next": "^26.3.6",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-i18next": "^17.0.11"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -32,6 +34,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-i18next": "^6.1.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
     "globals": "^17.11.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,12 @@
+import { useTranslation } from "react-i18next";
+
 export function App() {
+  const { t } = useTranslation("interface");
+
   return (
     <main>
-      <h1>Cicatrices de Acero</h1>
-      <p>Tu carrera como piloto está a punto de comenzar.</p>
+      <h1>{t("app.title")}</h1>
+      <p>{t("app.introduction")}</p>
     </main>
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,63 @@
+import { createInstance } from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import achievementsEn from "./locales/en/achievements.json";
+import decisionsEn from "./locales/en/decisions.json";
+import interfaceEn from "./locales/en/interface.json";
+import narrativeEn from "./locales/en/narrative.json";
+import nicknamesEn from "./locales/en/nicknames.json";
+import outcomesEn from "./locales/en/outcomes.json";
+import titlesEn from "./locales/en/titles.json";
+import zoidsEn from "./locales/en/zoids.json";
+import achievements from "./locales/es/achievements.json";
+import decisions from "./locales/es/decisions.json";
+import interfaceTranslations from "./locales/es/interface.json";
+import narrative from "./locales/es/narrative.json";
+import nicknames from "./locales/es/nicknames.json";
+import outcomes from "./locales/es/outcomes.json";
+import titles from "./locales/es/titles.json";
+import zoids from "./locales/es/zoids.json";
+
+export const defaultNamespace = "interface";
+export const resources = {
+  en: {
+    achievements: achievementsEn,
+    decisions: decisionsEn,
+    interface: interfaceEn,
+    narrative: narrativeEn,
+    nicknames: nicknamesEn,
+    outcomes: outcomesEn,
+    titles: titlesEn,
+    zoids: zoidsEn,
+  },
+  es: {
+    achievements,
+    decisions,
+    interface: interfaceTranslations,
+    narrative,
+    nicknames,
+    outcomes,
+    titles,
+    zoids,
+  },
+} as const;
+
+export const i18n = createInstance();
+
+void i18n.use(initReactI18next).init({
+  defaultNS: defaultNamespace,
+  fallbackLng: "en",
+  initAsync: false,
+  interpolation: {
+    escapeValue: false,
+  },
+  lng: "en",
+  missingKeyHandler: import.meta.env.DEV
+    ? (_languages, namespace, key) => {
+        throw new Error(`Missing translation key "${namespace}:${key}".`);
+      }
+    : undefined,
+  resources,
+  saveMissing: import.meta.env.DEV,
+  supportedLngs: ["en", "es"],
+});

--- a/src/i18next.d.ts
+++ b/src/i18next.d.ts
@@ -1,0 +1,10 @@
+import "i18next";
+
+import type { defaultNamespace, resources } from "./i18n";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    defaultNS: typeof defaultNamespace;
+    resources: (typeof resources)["en"];
+  }
+}

--- a/src/locales/en/achievements.json
+++ b/src/locales/en/achievements.json
@@ -1,0 +1,5 @@
+{
+  "firstVictory": {
+    "name": "First victory"
+  }
+}

--- a/src/locales/en/decisions.json
+++ b/src/locales/en/decisions.json
@@ -1,0 +1,5 @@
+{
+  "continue": {
+    "label": "Continue"
+  }
+}

--- a/src/locales/en/interface.json
+++ b/src/locales/en/interface.json
@@ -1,0 +1,6 @@
+{
+  "app": {
+    "introduction": "Your career as a pilot is about to begin.",
+    "title": "Scars of Steel"
+  }
+}

--- a/src/locales/en/narrative.json
+++ b/src/locales/en/narrative.json
@@ -1,0 +1,5 @@
+{
+  "pilot": {
+    "summary": "{{name}}, known as {{nickname}}, is {{age}} years old and belongs to the {{faction}}."
+  }
+}

--- a/src/locales/en/nicknames.json
+++ b/src/locales/en/nicknames.json
@@ -1,0 +1,3 @@
+{
+  "steelClaw": "Steel Claw"
+}

--- a/src/locales/en/outcomes.json
+++ b/src/locales/en/outcomes.json
@@ -1,0 +1,5 @@
+{
+  "victory": {
+    "title": "Victory"
+  }
+}

--- a/src/locales/en/titles.json
+++ b/src/locales/en/titles.json
@@ -1,0 +1,3 @@
+{
+  "rookiePilot": "Rookie pilot"
+}

--- a/src/locales/en/zoids.json
+++ b/src/locales/en/zoids.json
@@ -1,0 +1,5 @@
+{
+  "commandWolf": {
+    "name": "Command Wolf"
+  }
+}

--- a/src/locales/es/achievements.json
+++ b/src/locales/es/achievements.json
@@ -1,0 +1,5 @@
+{
+  "firstVictory": {
+    "name": "Primera victoria"
+  }
+}

--- a/src/locales/es/decisions.json
+++ b/src/locales/es/decisions.json
@@ -1,0 +1,5 @@
+{
+  "continue": {
+    "label": "Continuar"
+  }
+}

--- a/src/locales/es/interface.json
+++ b/src/locales/es/interface.json
@@ -1,0 +1,6 @@
+{
+  "app": {
+    "introduction": "Tu carrera como piloto está a punto de comenzar.",
+    "title": "Cicatrices de Acero"
+  }
+}

--- a/src/locales/es/narrative.json
+++ b/src/locales/es/narrative.json
@@ -1,0 +1,5 @@
+{
+  "pilot": {
+    "summary": "{{name}}, conocido como {{nickname}}, tiene {{age}} años y pertenece a {{faction}}."
+  }
+}

--- a/src/locales/es/nicknames.json
+++ b/src/locales/es/nicknames.json
@@ -1,0 +1,3 @@
+{
+  "steelClaw": "Garra de Acero"
+}

--- a/src/locales/es/outcomes.json
+++ b/src/locales/es/outcomes.json
@@ -1,0 +1,5 @@
+{
+  "victory": {
+    "title": "Victoria"
+  }
+}

--- a/src/locales/es/titles.json
+++ b/src/locales/es/titles.json
@@ -1,0 +1,3 @@
+{
+  "rookiePilot": "Piloto novato"
+}

--- a/src/locales/es/zoids.json
+++ b/src/locales/es/zoids.json
@@ -1,0 +1,5 @@
+{
+  "commandWolf": {
+    "name": "Command Wolf"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./app/App";
+import "./i18n";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -3,10 +3,13 @@ import { expect, test } from "vitest";
 
 import { App } from "../app/App";
 
-test("shows the game title", () => {
+test("shows the localized introduction", () => {
   render(<App />);
 
   expect(
-    screen.getByRole("heading", { name: "Cicatrices de Acero" }),
+    screen.getByRole("heading", { name: "Scars of Steel" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Your career as a pilot is about to begin."),
   ).toBeInTheDocument();
 });

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+
+import { i18n } from "../i18n";
+
+test("interpolates pilot values", () => {
+  expect(
+    i18n.t("pilot.summary", {
+      age: 18,
+      faction: "Helic Republic",
+      name: "Lena",
+      nickname: "Steel Claw",
+      ns: "narrative",
+    }),
+  ).toBe(
+    "Lena, known as Steel Claw, is 18 years old and belongs to the Helic Republic.",
+  );
+});
+
+test("provides Spanish resources", () => {
+  expect(i18n.getFixedT("es", "interface")("app.title")).toBe(
+    "Cicatrices de Acero",
+  );
+});
+
+test("throws when a translation key is missing", () => {
+  expect(() => i18n.t("missing.key" as never)).toThrowError(
+    'Missing translation key "interface:missing.key".',
+  );
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,1 +1,3 @@
 import "@testing-library/jest-dom/vitest";
+
+import "../i18n";


### PR DESCRIPTION
### Summary

Added typed English and Spanish localization resources with English as the default language. The application now uses i18next for visible text, validates translation keys during development, and rejects untranslated JSX text through ESLint.

### Ticket

- Closes https://github.com/TheCoreZi/scars-of-steel/issues/1

### Why

The application needs localization infrastructure before adding more interface and narrative content. Centralized resources let the UI change languages without modifying game rules.

### What changed

- Added English and Spanish resources for interface, narrative, decisions, outcomes, Zoids, titles, nicknames, and achievements
- Configured i18next and React i18next with typed keys and English as the default language
- Added development errors for missing translation keys
- Replaced visible text in `App` with localized interface keys
- Added ESLint validation that rejects literal text in JSX

### How to test

1. Run `npm install --registry=https://registry.npmjs.org/`.
2. Run `npm run dev`.
3. Open the URL shown by Vite.
4. Verify that the page shows `Scars of Steel`.
5. Verify that the introduction shows `Your career as a pilot is about to begin.`.
