### PR TITLE
Define domain contracts

### DIFF
--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,290 @@
+declare const boundedValueBrand: unique symbol;
+declare const warStateBrand: unique symbol;
+
+export type AchievementId = `achievement:${string}`;
+export type AcademyEventId = `academy-event:${string}`;
+export type Aspiration = "commander" | "shadow" | "war-hero" | "zoid-ace";
+export type BoundedValue = number & {
+  readonly [boundedValueBrand]: "BoundedValue";
+};
+export type DecisionId = `decision:${string}`;
+export type Faction = "guylos" | "helic";
+export type MilitaryRank =
+  | "cadet"
+  | "captain"
+  | "commander"
+  | "corporal"
+  | "general"
+  | "lieutenant"
+  | "major"
+  | "sergeant"
+  | "soldier";
+export type OutcomeId = `outcome:${string}`;
+export type OutcomeTag = `outcome-tag:${string}`;
+export type PilotId = `pilot:${string}`;
+export type SpecialRank =
+  | "blitz-orbit"
+  | "eizen-dragoons"
+  | "leo-master"
+  | "machinery-four"
+  | "prozen-knight"
+  | "tactical-master"
+  | "traitor";
+export type StatName =
+  "charisma" | "piloting" | "strength" | "synchrony" | "tactics" | "technique";
+export type TranslationKey<
+  Namespace extends TranslationNamespace = TranslationNamespace,
+> = `${Namespace}:${string}`;
+export type TranslationNamespace =
+  | "achievements"
+  | "decisions"
+  | "interface"
+  | "narrative"
+  | "nicknames"
+  | "outcomes"
+  | "titles"
+  | "zoids";
+export type ZoidCategory = "rare" | "standard" | "super-rare" | "weak";
+export type ZoidId = `zoid:${string}`;
+
+export interface Stats {
+  charisma: BoundedValue;
+  piloting: BoundedValue;
+  strength: BoundedValue;
+  synchrony: BoundedValue;
+  tactics: BoundedValue;
+  technique: BoundedValue;
+}
+
+export interface WarState {
+  guylos: BoundedValue;
+  helic: BoundedValue;
+  readonly [warStateBrand]: "WarState";
+}
+
+export interface MilitaryRankIndicator {
+  id: MilitaryRank;
+  kind: "military";
+}
+
+export interface SpecialRankIndicator {
+  id: SpecialRank;
+  kind: "special";
+  militaryRank: MilitaryRank;
+}
+
+export type RankIndicator = MilitaryRankIndicator | SpecialRankIndicator;
+
+export interface CareerIndicators {
+  combatPower: BoundedValue;
+  factionTrust: BoundedValue;
+  fame: BoundedValue;
+  rank: RankIndicator;
+  warState: WarState;
+}
+
+export interface StoredCareerData {
+  factionTrust: BoundedValue;
+  fame: BoundedValue;
+  militaryRank: MilitaryRank;
+  specialRank: SpecialRank | null;
+  warState: WarState;
+}
+
+interface PilotData {
+  age: number;
+  aspiration: Aspiration;
+  baseCombatPower: BoundedValue;
+  career: StoredCareerData;
+  faction: Faction;
+  id: PilotId;
+  name: string;
+  stats: Stats;
+}
+
+export interface PilotWithoutZoid extends PilotData {
+  zoids: null;
+}
+
+export interface PilotWithZoid extends PilotData {
+  zoids: {
+    reserveIds: readonly ZoidId[];
+    signatureId: ZoidId;
+  };
+}
+
+export type Pilot = PilotWithoutZoid | PilotWithZoid;
+
+export interface Zoid {
+  basePower: BoundedValue;
+  category: ZoidCategory;
+  faction: Faction;
+  id: ZoidId;
+  nameKey: TranslationKey<"zoids">;
+}
+
+export type StatChange =
+  | {
+      amount: number;
+      stat: StatName;
+      target: "stat";
+    }
+  | {
+      amount: number;
+      indicator: "faction-trust" | "fame";
+      target: "career-indicator";
+    }
+  | {
+      amount: number;
+      faction: Faction;
+      target: "war-state";
+    }
+  | {
+      amount: number;
+      target: "base-combat-power";
+    };
+
+export interface Outcome {
+  id: OutcomeId;
+  narrativeKey: TranslationKey<"outcomes">;
+  statChanges: readonly StatChange[];
+  tags: readonly OutcomeTag[];
+  zoidReward: ZoidCategory;
+}
+
+interface DecisionData {
+  descriptionKey: TranslationKey<"decisions">;
+  id: DecisionId;
+  labelKey: TranslationKey<"decisions">;
+}
+
+export interface ChanceDecision extends DecisionData {
+  baseSuccessChance: BoundedValue;
+  failureOutcome: Outcome;
+  kind: "chance";
+  outcome?: never;
+  primaryStat: StatName;
+  secondaryStats: readonly StatName[];
+  successOutcome: Outcome;
+}
+
+export interface SafeDecision extends DecisionData {
+  baseSuccessChance?: never;
+  failureOutcome?: never;
+  kind: "safe";
+  outcome: Outcome;
+  primaryStat?: never;
+  secondaryStats?: never;
+  successOutcome?: never;
+}
+
+export type Decision = ChanceDecision | SafeDecision;
+
+export interface AcademyEvent {
+  decisions: readonly [Decision, Decision, Decision];
+  id: AcademyEventId;
+  introductionKey: TranslationKey<"narrative">;
+  titleKey: TranslationKey<"narrative">;
+}
+
+export interface SafeDecisionResolution {
+  decisionId: DecisionId;
+  kind: "safe";
+  outcomeId: OutcomeId;
+}
+
+export interface ChanceDecisionResolution {
+  adjustedSuccessChance: BoundedValue;
+  decisionId: DecisionId;
+  kind: "chance";
+  outcomeId: OutcomeId;
+  result: "failure" | "success";
+  roll: BoundedValue;
+}
+
+export type DecisionResolution =
+  ChanceDecisionResolution | SafeDecisionResolution;
+
+export interface BattleRecord {
+  assigned: number;
+  losses: number;
+  wins: number;
+}
+
+export interface PilotDraft {
+  aspiration: Aspiration | null;
+  faction: Faction | null;
+  name: string;
+}
+
+export interface WelcomeGameState {
+  screen: "welcome";
+}
+
+export interface PilotCreationGameState {
+  draft: PilotDraft;
+  screen: "pilot-creation";
+}
+
+export interface ChoosingAcademyEventGameState {
+  eventId: AcademyEventId;
+  phase: "choosing";
+  pilot: PilotWithoutZoid;
+  screen: "academy-event";
+}
+
+export interface ResolvingAcademyEventGameState {
+  eventId: AcademyEventId;
+  phase: "resolving";
+  pilot: PilotWithoutZoid;
+  resolution: DecisionResolution;
+  screen: "academy-event";
+}
+
+export interface OutcomeGameState {
+  battleRecord: BattleRecord;
+  eventId: AcademyEventId;
+  pilot: PilotWithZoid;
+  resolution: DecisionResolution;
+  screen: "outcome";
+}
+
+export interface FinalGameState {
+  achievementIds: readonly AchievementId[];
+  eventId: AcademyEventId;
+  nicknameKey: TranslationKey<"nicknames">;
+  pilot: PilotWithZoid;
+  resolution: DecisionResolution;
+  screen: "final";
+  titleKey: TranslationKey<"titles">;
+}
+
+export type GameState =
+  | ChoosingAcademyEventGameState
+  | FinalGameState
+  | OutcomeGameState
+  | PilotCreationGameState
+  | ResolvingAcademyEventGameState
+  | WelcomeGameState;
+
+export function createBoundedValue(value: number): BoundedValue {
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new RangeError("The value must be a finite number from 0 to 100.");
+  }
+
+  return value as BoundedValue;
+}
+
+export function createWarState(helic: number, guylos: number): WarState {
+  const helicControl = createBoundedValue(helic);
+  const guylosControl = createBoundedValue(guylos);
+
+  if (helicControl + guylosControl !== 100) {
+    throw new RangeError("Faction control values must total 100.");
+  }
+
+  return {
+    guylos: guylosControl,
+    helic: helicControl,
+  } as WarState;
+}

--- a/src/tests/domain.test.ts
+++ b/src/tests/domain.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+
+import {
+  createBoundedValue,
+  createWarState,
+  type ChanceDecision,
+  type Decision,
+  type GameState,
+  type Outcome,
+  type PilotWithoutZoid,
+  type SafeDecision,
+  type Stats,
+} from "../domain/types";
+
+const zero = createBoundedValue(0);
+
+const outcome = {
+  id: "outcome:standard-zoid",
+  narrativeKey: "outcomes:academy.standardZoid",
+  statChanges: [],
+  tags: [],
+  zoidReward: "standard",
+} as const satisfies Outcome;
+
+const safeDecision = {
+  descriptionKey: "decisions:academy.acceptStandard.description",
+  id: "decision:accept-standard",
+  kind: "safe",
+  labelKey: "decisions:academy.acceptStandard.label",
+  outcome,
+} as const satisfies SafeDecision;
+
+const chanceDecision = {
+  baseSuccessChance: createBoundedValue(40),
+  descriptionKey: "decisions:academy.controlRare.description",
+  failureOutcome: outcome,
+  id: "decision:control-rare",
+  kind: "chance",
+  labelKey: "decisions:academy.controlRare.label",
+  primaryStat: "piloting",
+  secondaryStats: ["synchrony"],
+  successOutcome: outcome,
+} as const satisfies ChanceDecision;
+
+const stats = {
+  charisma: zero,
+  piloting: zero,
+  strength: zero,
+  synchrony: zero,
+  tactics: zero,
+  technique: zero,
+} satisfies Stats;
+
+const pilotWithoutZoid = {
+  age: 12,
+  aspiration: "zoid-ace",
+  baseCombatPower: zero,
+  career: {
+    factionTrust: zero,
+    fame: zero,
+    militaryRank: "cadet",
+    specialRank: null,
+    warState: createWarState(50, 50),
+  },
+  faction: "helic",
+  id: "pilot:test",
+  name: "Test Pilot",
+  stats,
+  zoids: null,
+} as const satisfies PilotWithoutZoid;
+
+describe("createBoundedValue", () => {
+  test.each([0, 100])("accepts the boundary value %s", (value) => {
+    expect(createBoundedValue(value)).toBe(value);
+  });
+
+  test.each([-1, 101, Number.NaN, Number.NEGATIVE_INFINITY, Infinity])(
+    "rejects the invalid value %s",
+    (value) => {
+      expect(() => createBoundedValue(value)).toThrow(RangeError);
+    },
+  );
+});
+
+describe("createWarState", () => {
+  test("accepts faction control values that total 100", () => {
+    expect(createWarState(50, 50)).toMatchObject({ guylos: 50, helic: 50 });
+  });
+
+  test.each([
+    [-1, 101],
+    [40, 40],
+    [50, Number.NaN],
+  ])("rejects the invalid control values %s and %s", (helic, guylos) => {
+    expect(() => createWarState(helic, guylos)).toThrow(RangeError);
+  });
+});
+
+test("defines valid decision contracts", () => {
+  expectTypeOf(safeDecision).toMatchTypeOf<Decision>();
+  expectTypeOf(chanceDecision).toMatchTypeOf<Decision>();
+});
+
+const incompleteStats: Omit<Stats, "tactics"> = {
+  charisma: zero,
+  piloting: zero,
+  strength: zero,
+  synchrony: zero,
+  technique: zero,
+};
+
+// @ts-expect-error All six pilot stats are required.
+const invalidStats: Stats = incompleteStats;
+
+// @ts-expect-error Safe decisions cannot define a success chance.
+const invalidSafeDecision: Decision = {
+  ...safeDecision,
+  baseSuccessChance: createBoundedValue(100),
+};
+
+// @ts-expect-error Chance decisions require success and failure outcomes.
+const invalidChanceDecision: Decision = {
+  baseSuccessChance: createBoundedValue(40),
+  descriptionKey: "decisions:academy.invalid.description",
+  id: "decision:invalid-chance",
+  kind: "chance",
+  labelKey: "decisions:academy.invalid.label",
+  primaryStat: "piloting",
+  secondaryStats: [],
+};
+
+const choosingState = {
+  eventId: "academy-event:first-exercises",
+  phase: "choosing",
+  pilot: pilotWithoutZoid,
+  screen: "academy-event",
+} as const satisfies GameState;
+
+// @ts-expect-error Resolving an event requires a stored resolution.
+const invalidResolvingState: GameState = {
+  ...choosingState,
+  phase: "resolving",
+};
+
+const invalidFinalState: GameState = {
+  achievementIds: [],
+  eventId: "academy-event:first-exercises",
+  nicknameKey: "nicknames:default.guardian",
+  // @ts-expect-error The final screen requires a pilot with a signature Zoid.
+  pilot: pilotWithoutZoid,
+  resolution: {
+    decisionId: "decision:accept-standard",
+    kind: "safe",
+    outcomeId: "outcome:standard-zoid",
+  },
+  screen: "final",
+  titleKey: "titles:villageHero",
+};
+
+void invalidChanceDecision;
+void invalidFinalState;
+void invalidResolvingState;
+void invalidSafeDecision;
+void invalidStats;


### PR DESCRIPTION
## Summary

- Add stable domain contracts for pilots, Zoids, career indicators, decisions, outcomes, and Academy events.
- Model the five v0.1 screens with discriminated game states.
- Separate stored career data from calculated indicators.
- Validate bounded values and faction control totals.
- Prevent invalid decision and pilot states through TypeScript.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:run`
- `npm run build`

Closes #14