### PR TITLE
Centralize random number generation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,14 @@ export default defineConfig([
     },
     rules: {
       "i18next/no-literal-string": ["error", { mode: "jsx-only" }],
+      "no-restricted-properties": [
+        "error",
+        {
+          message: "Use RandomGenerator instead.",
+          object: "Math",
+          property: "random",
+        },
+      ],
     },
   },
 ]);

--- a/src/domain/random.ts
+++ b/src/domain/random.ts
@@ -1,0 +1,129 @@
+const UINT32_RANGE = 0x1_0000_0000;
+
+export interface RandomGenerator {
+  chance(probability: number): boolean;
+  integer(min: number, max: number): number;
+  probability(): number;
+  weighted<T>(entries: readonly WeightedEntry<T>[]): T;
+}
+
+export interface WeightedEntry<T> {
+  value: T;
+  weight: number;
+}
+
+export function createSecureRandomGenerator(): RandomGenerator {
+  const values = new Uint32Array(1);
+
+  return createRandomGenerator(() => {
+    crypto.getRandomValues(values);
+    return values[0];
+  });
+}
+
+export function createSeededRandomGenerator(seed: number): RandomGenerator {
+  validateUint32(seed, "The seed");
+
+  let state = seed;
+
+  return createRandomGenerator(() => {
+    state = (state + 0x6d2b79f5) >>> 0;
+
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+
+    return (value ^ (value >>> 14)) >>> 0;
+  });
+}
+
+function createRandomGenerator(nextUint32: () => number): RandomGenerator {
+  const probability = () => nextUint32() / UINT32_RANGE;
+
+  return {
+    chance: (chance) => {
+      validateProbability(chance);
+      return probability() < chance;
+    },
+    integer: (min, max) => {
+      validateIntegerRange(min, max);
+
+      const range = max - min + 1;
+      const limit = UINT32_RANGE - (UINT32_RANGE % range);
+      let value: number;
+
+      do {
+        value = nextUint32();
+      } while (value >= limit);
+
+      return min + (value % range);
+    },
+    probability,
+    weighted: (entries) => {
+      const totalWeight = validateWeights(entries);
+      const selection = probability() * totalWeight;
+      let accumulatedWeight = 0;
+
+      for (const entry of entries) {
+        accumulatedWeight += entry.weight;
+        if (selection < accumulatedWeight) {
+          return entry.value;
+        }
+      }
+
+      return entries[entries.length - 1].value;
+    },
+  };
+}
+
+function validateProbability(probability: number): void {
+  if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+    throw new RangeError(
+      "The probability must be a finite number from 0 to 1.",
+    );
+  }
+}
+
+function validateIntegerRange(min: number, max: number): void {
+  if (!Number.isSafeInteger(min) || !Number.isSafeInteger(max) || min > max) {
+    throw new RangeError(
+      "The minimum and maximum must be safe integers in ascending order.",
+    );
+  }
+
+  if (max - min + 1 > UINT32_RANGE) {
+    throw new RangeError(
+      "The integer range cannot contain more than 2^32 values.",
+    );
+  }
+}
+
+function validateUint32(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0 || value >= UINT32_RANGE) {
+    throw new RangeError(`${name} must be an integer from 0 to 2^32 - 1.`);
+  }
+}
+
+function validateWeights<T>(entries: readonly WeightedEntry<T>[]): number {
+  if (entries.length === 0) {
+    throw new RangeError("The weighted entries cannot be empty.");
+  }
+
+  let totalWeight = 0;
+
+  for (const entry of entries) {
+    if (!Number.isFinite(entry.weight) || entry.weight < 0) {
+      throw new RangeError("Each weight must be a finite non-negative number.");
+    }
+
+    totalWeight += entry.weight;
+  }
+
+  if (!Number.isFinite(totalWeight) || totalWeight === 0) {
+    throw new RangeError(
+      "The total weight must be finite and greater than zero.",
+    );
+  }
+
+  return totalWeight;
+}

--- a/src/tests/eslint.test.ts
+++ b/src/tests/eslint.test.ts
@@ -1,0 +1,16 @@
+import { ESLint } from "eslint";
+import { expect, test } from "vitest";
+
+test("rejects direct Math.random calls", async () => {
+  const eslint = new ESLint();
+  const [result] = await eslint.lintText("Math.random();", {
+    filePath: "forbidden.ts",
+  });
+
+  expect(result.messages).toContainEqual(
+    expect.objectContaining({
+      ruleId: "no-restricted-properties",
+      severity: 2,
+    }),
+  );
+});

--- a/src/tests/random.test.ts
+++ b/src/tests/random.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+
+import {
+  createSecureRandomGenerator,
+  createSeededRandomGenerator,
+  type RandomGenerator,
+} from "../domain/random";
+
+describe("createSecureRandomGenerator", () => {
+  test("creates a replaceable random generator", () => {
+    expectTypeOf(
+      createSecureRandomGenerator(),
+    ).toMatchTypeOf<RandomGenerator>();
+  });
+
+  test("generates probabilities in the supported range", () => {
+    const random = createSecureRandomGenerator();
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      expect(random.probability()).toBeGreaterThanOrEqual(0);
+      expect(random.probability()).toBeLessThan(1);
+    }
+  });
+});
+
+describe("createSeededRandomGenerator", () => {
+  test("produces the same sequence for the same seed", () => {
+    const first = createSeededRandomGenerator(42);
+    const second = createSeededRandomGenerator(42);
+
+    expect(Array.from({ length: 10 }, () => first.probability())).toEqual(
+      Array.from({ length: 10 }, () => second.probability()),
+    );
+  });
+
+  test("produces different sequences for different seeds", () => {
+    const first = createSeededRandomGenerator(1);
+    const second = createSeededRandomGenerator(2);
+
+    expect(Array.from({ length: 10 }, () => first.probability())).not.toEqual(
+      Array.from({ length: 10 }, () => second.probability()),
+    );
+  });
+
+  test.each([-1, 0x1_0000_0000, 1.5, Number.NaN, Infinity])(
+    "rejects the invalid seed %s",
+    (seed) => {
+      expect(() => createSeededRandomGenerator(seed)).toThrow(RangeError);
+    },
+  );
+});
+
+describe("chance", () => {
+  test("supports the probability boundaries", () => {
+    const random = createSeededRandomGenerator(42);
+
+    expect(random.chance(0)).toBe(false);
+    expect(random.chance(1)).toBe(true);
+  });
+
+  test("supports intermediate probabilities", () => {
+    const random: RandomGenerator = {
+      chance: (probability) => probability > 0.25,
+      integer: () => 0,
+      probability: () => 0.25,
+      weighted: (entries) => entries[0].value,
+    };
+
+    expect(random.chance(0.5)).toBe(true);
+  });
+
+  test.each([-1, 1.1, Number.NaN, Infinity])(
+    "rejects the invalid probability %s",
+    (probability) => {
+      expect(() => createSeededRandomGenerator(42).chance(probability)).toThrow(
+        RangeError,
+      );
+    },
+  );
+});
+
+describe("integer", () => {
+  test("includes both boundaries", () => {
+    const random = createSeededRandomGenerator(42);
+    const values = new Set(
+      Array.from({ length: 100 }, () => random.integer(-1, 1)),
+    );
+
+    expect(values).toEqual(new Set([-1, 0, 1]));
+  });
+
+  test("supports a range with one value", () => {
+    expect(createSeededRandomGenerator(42).integer(5, 5)).toBe(5);
+  });
+
+  test.each([
+    [1.5, 2],
+    [1, 2.5],
+    [2, 1],
+    [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+  ])("rejects the invalid range %s to %s", (min, max) => {
+    expect(() => createSeededRandomGenerator(42).integer(min, max)).toThrow(
+      RangeError,
+    );
+  });
+});
+
+describe("weighted", () => {
+  test("selects entries according to their weights", () => {
+    const random = createSeededRandomGenerator(42);
+    const entries = [
+      { value: "common", weight: 8 },
+      { value: "rare", weight: 2 },
+    ] as const;
+    const values = new Set(
+      Array.from({ length: 100 }, () => random.weighted(entries)),
+    );
+
+    expect(values).toEqual(new Set(["common", "rare"]));
+  });
+
+  test("does not select entries with zero weight", () => {
+    const random = createSeededRandomGenerator(42);
+
+    expect(
+      Array.from({ length: 100 }, () =>
+        random.weighted([
+          { value: "never", weight: 0 },
+          { value: "always", weight: 1 },
+        ]),
+      ),
+    ).toEqual(Array.from({ length: 100 }, () => "always"));
+  });
+
+  test.each([
+    [[]],
+    [[{ value: "invalid", weight: -1 }]],
+    [[{ value: "invalid", weight: Number.NaN }]],
+    [[{ value: "invalid", weight: Infinity }]],
+    [[{ value: "invalid", weight: 0 }]],
+  ])("rejects invalid entries %#", (entries) => {
+    expect(() => createSeededRandomGenerator(42).weighted(entries)).toThrow(
+      RangeError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared random generator interface for probabilities, inclusive integers, and weighted selection
- use Web Crypto in production and a seeded generator in deterministic tests
- reject direct Math.random calls through ESLint
- keep random seeds and generator state out of GameState

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm run test:run
- npm run build

Closes #2