### PR TITLE
Add initial pilot factions, aspirations, and stats

### DIFF
--- a/src/domain/pilot.ts
+++ b/src/domain/pilot.ts
@@ -1,0 +1,115 @@
+import {
+  createBoundedValue,
+  createWarState,
+  type Aspiration,
+  type Faction,
+  type PilotId,
+  type PilotWithoutZoid,
+  type StatName,
+  type Stats,
+  type TranslationKey,
+} from "./types";
+
+const initialStats = {
+  commander: {
+    charisma: 5,
+    piloting: 2,
+    strength: 3,
+    synchrony: 3,
+    tactics: 4,
+    technique: 3,
+  },
+  shadow: {
+    charisma: 2,
+    piloting: 4,
+    strength: 3,
+    synchrony: 3,
+    tactics: 5,
+    technique: 3,
+  },
+  "war-hero": {
+    charisma: 3,
+    piloting: 5,
+    strength: 4,
+    synchrony: 2,
+    tactics: 3,
+    technique: 3,
+  },
+  "zoid-ace": {
+    charisma: 3,
+    piloting: 3,
+    strength: 2,
+    synchrony: 5,
+    tactics: 3,
+    technique: 4,
+  },
+} as const satisfies Record<Aspiration, Record<StatName, number>>;
+
+export const aspirationNameKeys = {
+  commander: "interface:aspirations.commander",
+  shadow: "interface:aspirations.shadow",
+  "war-hero": "interface:aspirations.warHero",
+  "zoid-ace": "interface:aspirations.zoidAce",
+} as const satisfies Record<Aspiration, TranslationKey<"interface">>;
+
+export const factionNameKeys = {
+  guylos: "interface:factions.guylos",
+  helic: "interface:factions.helic",
+} as const satisfies Record<Faction, TranslationKey<"interface">>;
+
+export interface InitialPilotData {
+  aspiration: Aspiration;
+  faction: Faction;
+  id: PilotId;
+  name: string;
+}
+
+export function createInitialPilot({
+  aspiration,
+  faction,
+  id,
+  name,
+}: InitialPilotData): PilotWithoutZoid {
+  const zero = createBoundedValue(0);
+
+  return {
+    age: 12,
+    aspiration,
+    baseCombatPower: zero,
+    career: {
+      factionTrust: zero,
+      fame: zero,
+      militaryRank: "cadet",
+      specialRank: null,
+      warState: createWarState(50, 50),
+    },
+    faction,
+    id,
+    name: normalizePilotName(name),
+    stats: getInitialStats(aspiration),
+    zoids: null,
+  };
+}
+
+export function normalizePilotName(name: string): string {
+  const normalizedName = name.normalize().trim().replace(/\s+/gu, " ");
+
+  if (!normalizedName) {
+    throw new TypeError("Pilot name must not be empty.");
+  }
+
+  return normalizedName;
+}
+
+export function getInitialStats(aspiration: Aspiration): Stats {
+  const stats = initialStats[aspiration];
+
+  return {
+    charisma: createBoundedValue(stats.charisma),
+    piloting: createBoundedValue(stats.piloting),
+    strength: createBoundedValue(stats.strength),
+    synchrony: createBoundedValue(stats.synchrony),
+    tactics: createBoundedValue(stats.tactics),
+    technique: createBoundedValue(stats.technique),
+  };
+}

--- a/src/locales/en/interface.json
+++ b/src/locales/en/interface.json
@@ -2,5 +2,15 @@
   "app": {
     "introduction": "Your career as a pilot is about to begin.",
     "title": "Scars of Steel"
+  },
+  "aspirations": {
+    "commander": "Commander",
+    "shadow": "Shadow",
+    "warHero": "War hero",
+    "zoidAce": "Zoid Ace"
+  },
+  "factions": {
+    "guylos": "Guylos Empire",
+    "helic": "Helic Republic"
   }
 }

--- a/src/locales/es/interface.json
+++ b/src/locales/es/interface.json
@@ -2,5 +2,15 @@
   "app": {
     "introduction": "Tu carrera como piloto está a punto de comenzar.",
     "title": "Cicatrices de Acero"
+  },
+  "aspirations": {
+    "commander": "Comandante",
+    "shadow": "Sombra",
+    "warHero": "Héroe de guerra",
+    "zoidAce": "As de Zoids"
+  },
+  "factions": {
+    "guylos": "Imperio de Guylos",
+    "helic": "República de Helic"
   }
 }

--- a/src/tests/pilot.test.ts
+++ b/src/tests/pilot.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  aspirationNameKeys,
+  createInitialPilot,
+  factionNameKeys,
+  getInitialStats,
+  normalizePilotName,
+} from "../domain/pilot";
+import type { Aspiration, Faction } from "../domain/types";
+
+const aspirations = Object.keys(aspirationNameKeys) as Aspiration[];
+const factions = Object.keys(factionNameKeys) as Faction[];
+
+describe("getInitialStats", () => {
+  test.each(aspirations)("assigns 20 points to %s", (aspiration) => {
+    const total = Object.values(getInitialStats(aspiration)).reduce(
+      (sum, stat) => sum + stat,
+      0,
+    );
+
+    expect(total).toBe(20);
+  });
+
+  test.each([
+    ["commander", [5, 2, 3, 3, 4, 3]],
+    ["shadow", [2, 4, 3, 3, 5, 3]],
+    ["war-hero", [3, 5, 4, 2, 3, 3]],
+    ["zoid-ace", [3, 3, 2, 5, 3, 4]],
+  ] as const)("assigns the fixed profile to %s", (aspiration, expected) => {
+    expect(Object.values(getInitialStats(aspiration))).toEqual(expected);
+  });
+});
+
+describe("createInitialPilot", () => {
+  test.each(factions)("uses the same initial rules for %s", (faction) => {
+    const pilot = createInitialPilot({
+      aspiration: "zoid-ace",
+      faction,
+      id: "pilot:test",
+      name: "  Lena\n\tSteel  ",
+    });
+
+    expect(pilot).toMatchObject({
+      age: 12,
+      baseCombatPower: 0,
+      career: {
+        factionTrust: 0,
+        fame: 0,
+        militaryRank: "cadet",
+        specialRank: null,
+        warState: { guylos: 50, helic: 50 },
+      },
+      faction,
+      name: "Lena Steel",
+      zoids: null,
+    });
+  });
+});
+
+describe("normalizePilotName", () => {
+  test("normalizes Unicode and whitespace", () => {
+    expect(normalizePilotName("  Le\u0301na\u00a0Steel  ")).toBe("Léna Steel");
+  });
+
+  test("rejects an empty name", () => {
+    expect(() => normalizePilotName(" \n\t ")).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

- Add localized faction and aspiration definitions.
- Create pilots with fixed aspiration stats and initial career indicators.
- Normalize pilot names and reject empty names.
- Test all aspirations and both factions.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:run`
- `npm run build`

Closes #3.