### PR TITLE
Add localized responsive welcome screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,70 @@
+import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { PilotCreationGameState, WelcomeGameState } from "../domain/types";
+import { Badge, Panel } from "./UiPrimitives";
+import { WelcomeScreen } from "./WelcomeScreen";
+
+type ColorMode = "dark" | "light";
+type IntroGameState = PilotCreationGameState | WelcomeGameState;
+
 export function App() {
-  const { t } = useTranslation("interface");
+  const [colorMode, setColorMode] = useState<ColorMode>("dark");
+  const [gameState, setGameState] = useState<IntroGameState>({
+    screen: "welcome",
+  });
+  function startGame() {
+    setGameState((currentState) =>
+      currentState.screen === "welcome"
+        ? {
+            draft: {
+              aspiration: null,
+              faction: null,
+              name: "",
+            },
+            screen: "pilot-creation",
+          }
+        : currentState,
+    );
+  }
 
   return (
-    <main>
-      <h1>{t("app.title")}</h1>
-      <p>{t("app.introduction")}</p>
+    <div
+      className="app-shell"
+      data-color-mode={colorMode}
+      data-faction="neutral"
+    >
+      {gameState.screen === "welcome" ? (
+        <WelcomeScreen
+          colorMode={colorMode}
+          onColorModeChange={setColorMode}
+          onStart={startGame}
+        />
+      ) : (
+        <PilotCreationStart />
+      )}
+    </div>
+  );
+}
+
+function PilotCreationStart() {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const titleId = useId();
+  const { t } = useTranslation("interface");
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <main className="screen screen--centered">
+      <Panel className="pilot-start" labelledBy={titleId}>
+        <Badge>{t("pilotCreation.badge")}</Badge>
+        <h1 id={titleId} ref={headingRef} tabIndex={-1}>
+          {t("pilotCreation.title")}
+        </h1>
+        <p>{t("pilotCreation.description")}</p>
+      </Panel>
     </main>
   );
 }

--- a/src/app/UiPrimitives.tsx
+++ b/src/app/UiPrimitives.tsx
@@ -1,0 +1,66 @@
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  PropsWithChildren,
+} from "react";
+
+interface BadgeProps extends PropsWithChildren {
+  className?: string;
+}
+
+interface MeterProps {
+  label: string;
+  value: number;
+}
+
+interface PanelProps extends PropsWithChildren {
+  className?: string;
+  labelledBy?: string;
+}
+
+export function Badge({ children, className = "" }: BadgeProps) {
+  return <span className={`badge ${className}`.trim()}>{children}</span>;
+}
+
+export function Button({
+  children,
+  className = "",
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className={`button ${className}`.trim()} type={type} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export function Meter({ label, value }: MeterProps) {
+  return (
+    <div className="meter">
+      <span className="meter__label">{label}</span>
+      <div
+        aria-label={label}
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={value}
+        className="meter__track"
+        role="progressbar"
+      >
+        <span className="meter__value" style={{ width: `${value}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function Panel({ children, className = "", labelledBy }: PanelProps) {
+  const accessibilityProps: HTMLAttributes<HTMLElement> = labelledBy
+    ? { "aria-labelledby": labelledBy }
+    : {};
+
+  return (
+    <section className={`panel ${className}`.trim()} {...accessibilityProps}>
+      {children}
+    </section>
+  );
+}

--- a/src/app/WelcomeScreen.tsx
+++ b/src/app/WelcomeScreen.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Badge, Button, Panel } from "./UiPrimitives";
+
+const welcomeFacts = {
+  decisions: 5,
+  factions: 2,
+  paths: 21,
+  wars: 1,
+} as const;
+
+type ColorMode = "dark" | "light";
+type Language = "en" | "es";
+
+const languages: Language[] = ["en", "es"];
+
+interface WelcomeScreenProps {
+  colorMode: ColorMode;
+  onColorModeChange: (colorMode: ColorMode) => void;
+  onStart: () => void;
+}
+
+export function WelcomeScreen({
+  colorMode,
+  onColorModeChange,
+  onStart,
+}: WelcomeScreenProps) {
+  const [started, setStarted] = useState(false);
+  const startedRef = useRef(false);
+  const titleId = useId();
+  const { i18n, t } = useTranslation("interface");
+
+  useEffect(() => {
+    document.documentElement.lang = i18n.resolvedLanguage ?? "en";
+  }, [i18n.resolvedLanguage]);
+
+  function changeLanguage(language: Language) {
+    void i18n.changeLanguage(language);
+  }
+
+  function handleStart() {
+    if (startedRef.current) {
+      return;
+    }
+
+    startedRef.current = true;
+    setStarted(true);
+    onStart();
+  }
+
+  function toggleColorMode() {
+    onColorModeChange(colorMode === "dark" ? "light" : "dark");
+  }
+
+  return (
+    <main className="screen welcome">
+      <div aria-hidden="true" className="welcome__damage">
+        <div className="welcome__claws">
+          <span />
+          <span />
+          <span />
+        </div>
+        <div className="welcome__bullets">
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+        </div>
+      </div>
+      <div className="welcome__controls">
+        <div
+          aria-label={t("welcome.language.label")}
+          className="language-selector"
+          role="group"
+        >
+          {languages.map((language) => (
+            <button
+              aria-label={t(`welcome.language.${language}`)}
+              aria-pressed={i18n.resolvedLanguage === language}
+              key={language}
+              onClick={() => changeLanguage(language)}
+              type="button"
+            >
+              {language.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        <button
+          aria-checked={colorMode === "light"}
+          aria-label={t("welcome.colorMode.light")}
+          className="color-mode-toggle"
+          onClick={toggleColorMode}
+          role="switch"
+          type="button"
+        >
+          <span aria-hidden="true" className="color-mode-toggle__icon" />
+        </button>
+      </div>
+      <Panel className="welcome__panel" labelledBy={titleId}>
+        <div className="welcome__signal" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+        <Badge>{t("welcome.badge")}</Badge>
+        <div className="welcome__heading">
+          <h1 id={titleId}>{t("welcome.title")}</h1>
+          <p className="welcome__description">{t("welcome.description")}</p>
+          <p className="welcome__journey">{t("welcome.journey")}</p>
+          <p className="welcome__call-to-action">{t("welcome.callToAction")}</p>
+        </div>
+        <dl aria-label={t("welcome.facts.label")} className="welcome__facts">
+          <div>
+            <dd>{welcomeFacts.factions}</dd>
+            <dt>{t("welcome.facts.factions")}</dt>
+          </div>
+          <div>
+            <dd>{welcomeFacts.decisions}</dd>
+            <dt>{t("welcome.facts.decisions")}</dt>
+          </div>
+          <div>
+            <dd>{welcomeFacts.paths}</dd>
+            <dt>{t("welcome.facts.paths")}</dt>
+          </div>
+          <div>
+            <dd>{welcomeFacts.wars}</dd>
+            <dt>{t("welcome.facts.wars")}</dt>
+          </div>
+        </dl>
+        <Button disabled={started} onClick={handleStart}>
+          {t("welcome.start")}
+        </Button>
+      </Panel>
+    </main>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,26 +1,1168 @@
 :root {
-  color: #f5f5f5;
-  background: #111827;
-  font-family: system-ui, sans-serif;
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+
+  --motion-fast: 140ms;
+  --motion-standard: 240ms;
+  --radius-medium: 0.75rem;
+  --radius-large: 1.5rem;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
+  min-width: 20rem;
   margin: 0;
 }
 
-main {
-  display: grid;
-  min-height: 100vh;
-  place-content: center;
-  padding: 1.5rem;
-  text-align: center;
+button,
+input {
+  font: inherit;
+}
+
+button {
+  -webkit-tap-highlight-color: transparent;
 }
 
 h1,
+h2,
 p {
   margin: 0;
 }
 
+h1,
+h2 {
+  color: var(--color-heading);
+  font-family: var(--font-heading);
+  letter-spacing: 0.015em;
+  line-height: 0.96;
+  text-transform: uppercase;
+}
+
 p {
-  margin-top: 1rem;
+  color: var(--color-text-muted);
+  line-height: 1.65;
+}
+
+.app-shell {
+  --color-accent: #f4b942;
+  --color-accent-contrast: #18140a;
+  --color-accent-soft: rgb(244 185 66 / 18%);
+  --color-background: #071126;
+  --color-border: #485981;
+  --color-border-strong: #7b8fc8;
+  --color-heading: #ffffff;
+  --color-panel: rgb(13 25 53 / 94%);
+  --color-panel-raised: #172b58;
+  --color-text: #f7f9ff;
+  --color-text-muted: #bdc9e8;
+  --damage-dark: #01040a;
+  --damage-metal: #536079;
+  --font-body: Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-heading: "Arial Narrow", "Roboto Condensed", Inter, sans-serif;
+  --shadow-panel: 0 2rem 7rem rgb(13 38 94 / 58%);
+  --title-metal-accent: #4b566a;
+  --title-metal-dark: #4b566a;
+  --title-metal-light: #f9fcff;
+  --title-metal-mid: #9ca9bc;
+  --title-metal-stroke: #111a2c;
+
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-x: hidden;
+  isolation: isolate;
+  position: relative;
+  color-scheme: dark;
+  color: var(--color-text);
+  background-color: var(--color-background);
+  background-image:
+    repeating-linear-gradient(
+      168deg,
+      transparent 0 2.8rem,
+      color-mix(in srgb, var(--color-border) 22%, transparent) 2.85rem 2.92rem,
+      transparent 2.98rem 5.7rem
+    ),
+    repeating-linear-gradient(
+      112deg,
+      transparent 0 4.2rem,
+      color-mix(in srgb, var(--color-accent) 9%, transparent) 4.25rem 4.34rem,
+      transparent 4.4rem 8.4rem
+    ),
+    radial-gradient(
+      circle at 76% 26%,
+      var(--color-accent-soft),
+      transparent 36%
+    ),
+    linear-gradient(145deg, var(--color-panel-raised), var(--color-background));
+  background-size: auto;
+  font-family: var(--font-body);
+  transition:
+    background-color var(--motion-standard) ease,
+    color var(--motion-standard) ease;
+}
+
+.app-shell[data-faction="guylos"] {
+  --color-accent: #ff5d6c;
+  --color-accent-contrast: #210508;
+  --color-accent-soft: rgb(255 93 108 / 20%);
+  --color-border-strong: #9f4350;
+}
+
+.app-shell[data-faction="helic"] {
+  --color-accent: #4bd9ff;
+  --color-accent-contrast: #03151b;
+  --color-accent-soft: rgb(75 217 255 / 20%);
+  --color-border-strong: #317f95;
+}
+
+.app-shell[data-color-mode="light"] {
+  --color-accent: #965b00;
+  --color-accent-contrast: #ffffff;
+  --color-accent-soft: rgb(150 91 0 / 16%);
+  --color-background: #e7ecf8;
+  --color-border: #9ba8c8;
+  --color-border-strong: #9b792e;
+  --color-heading: #101b38;
+  --color-panel: rgb(248 250 255 / 96%);
+  --color-panel-raised: #dce5fa;
+  --color-text: #14203e;
+  --color-text-muted: #485677;
+  --damage-dark: #252b35;
+  --damage-metal: #a9b1c0;
+  --shadow-panel: 0 2rem 5rem rgb(37 50 87 / 20%);
+  --title-metal-accent: #754300;
+  --title-metal-dark: #4d2900;
+  --title-metal-light: #d19a43;
+  --title-metal-mid: var(--color-accent);
+  --title-metal-stroke: #351b00;
+
+  color-scheme: light;
+}
+
+.app-shell[data-color-mode="light"][data-faction="guylos"] {
+  --color-accent: #b2243a;
+  --color-accent-contrast: #ffffff;
+  --color-accent-soft: rgb(178 36 58 / 16%);
+  --color-border-strong: #a54855;
+}
+
+.app-shell[data-color-mode="light"][data-faction="helic"] {
+  --color-accent: #006d8f;
+  --color-accent-contrast: #ffffff;
+  --color-accent-soft: rgb(0 109 143 / 16%);
+  --color-border-strong: #397b90;
+}
+
+.screen {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: clamp(var(--space-4), 4vw, var(--space-7));
+}
+
+.screen--centered,
+.welcome {
+  place-items: center;
+}
+
+.panel {
+  position: relative;
+  border: 1px solid var(--color-border);
+  border-top: 0.4rem solid var(--color-accent);
+  border-radius: var(--radius-large);
+  background: var(--color-panel);
+  box-shadow: var(--shadow-panel);
+}
+
+.badge {
+  display: inline-flex;
+  min-height: 1.75rem;
+  align-items: center;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 999px;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-6);
+  border: 1px solid var(--color-accent);
+  border-radius: 999px;
+  color: var(--color-accent-contrast);
+  background: var(--color-accent);
+  box-shadow:
+    0 0 0 0.4rem var(--color-accent-soft),
+    0 1rem 3rem var(--color-accent-soft);
+  cursor: pointer;
+  font-weight: 850;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+  transition:
+    box-shadow var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
+}
+
+.button:hover:not(:disabled) {
+  box-shadow:
+    0 0 0 0.5rem var(--color-accent-soft),
+    0 1.25rem 3.5rem var(--color-accent-soft);
+  transform: translateY(-2px);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.button:focus-visible,
+.color-mode-toggle:focus-visible,
+.language-selector button:focus-visible {
+  outline: 3px solid var(--color-heading);
+  outline-offset: 3px;
+}
+
+.welcome__controls {
+  position: fixed;
+  z-index: 10;
+  top: var(--space-4);
+  right: var(--space-4);
+  display: flex;
+  gap: var(--space-2);
+}
+
+.language-selector {
+  display: flex;
+  overflow: hidden;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-panel) 84%, var(--color-accent));
+  box-shadow: 0 0.75rem 2rem rgb(0 0 0 / 22%);
+}
+
+.language-selector button {
+  min-width: 3rem;
+  min-height: 3rem;
+  padding: 0 var(--space-3);
+  border: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+}
+
+.language-selector button[aria-pressed="true"] {
+  color: var(--color-accent-contrast);
+  background: var(--color-accent);
+}
+
+.color-mode-toggle {
+  --toggle-surface: color-mix(
+    in srgb,
+    var(--color-panel) 84%,
+    var(--color-accent)
+  );
+
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 50%;
+  color: var(--color-accent);
+  background: var(--toggle-surface);
+  box-shadow: 0 0.75rem 2rem rgb(0 0 0 / 22%);
+  cursor: pointer;
+  transition:
+    background-color var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
+}
+
+.color-mode-toggle:hover {
+  transform: translateY(-2px);
+}
+
+.color-mode-toggle:active {
+  transform: translateY(0);
+}
+
+.color-mode-toggle__icon {
+  position: relative;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0.8rem var(--color-accent-soft);
+}
+
+.color-mode-toggle[aria-checked="false"] .color-mode-toggle__icon::after {
+  position: absolute;
+  top: -0.2rem;
+  left: 0.35rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--toggle-surface);
+  content: "";
+}
+
+.color-mode-toggle[aria-checked="true"] .color-mode-toggle__icon {
+  width: 0.7rem;
+  height: 0.7rem;
+  box-shadow:
+    0 -0.58rem 0 -0.22rem currentColor,
+    0 0.58rem 0 -0.22rem currentColor,
+    0.58rem 0 0 -0.22rem currentColor,
+    -0.58rem 0 0 -0.22rem currentColor,
+    0.41rem 0.41rem 0 -0.22rem currentColor,
+    -0.41rem 0.41rem 0 -0.22rem currentColor,
+    0.41rem -0.41rem 0 -0.22rem currentColor,
+    -0.41rem -0.41rem 0 -0.22rem currentColor;
+}
+
+.welcome__panel {
+  z-index: 1;
+  display: grid;
+  width: min(100%, 76rem);
+  min-height: min(46rem, calc(100dvh - 6rem));
+  overflow: hidden;
+  grid-template-areas:
+    "badge facts"
+    "heading facts"
+    "button facts";
+  grid-template-columns: minmax(0, 1.45fr) minmax(17rem, 0.55fr);
+  grid-template-rows: auto 1fr auto;
+  gap: clamp(var(--space-5), 4vw, var(--space-7));
+  column-gap: clamp(var(--space-6), 6vw, var(--space-8));
+  padding: clamp(var(--space-5), 6vw, var(--space-8));
+  background:
+    linear-gradient(112deg, rgb(12 25 54 / 96%) 0 64%, transparent 64%),
+    linear-gradient(
+      112deg,
+      transparent 0 62%,
+      var(--color-accent-soft) 62% 100%
+    ),
+    var(--color-panel-raised);
+  box-shadow:
+    0 2rem 7rem rgb(3 8 24 / 70%),
+    inset 0 0 0 1px var(--color-border);
+}
+
+.app-shell[data-color-mode="light"] .welcome__panel {
+  background:
+    linear-gradient(112deg, rgb(248 250 255 / 96%) 0 64%, transparent 64%),
+    linear-gradient(
+      112deg,
+      transparent 0 62%,
+      var(--color-accent-soft) 62% 100%
+    ),
+    var(--color-panel-raised);
+}
+
+.welcome__panel::after {
+  position: absolute;
+  top: 8%;
+  right: -5rem;
+  width: 26rem;
+  aspect-ratio: 1;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle,
+      transparent 0 34%,
+      var(--color-accent-soft) 34% 35%,
+      transparent 35% 52%,
+      var(--color-accent-soft) 52% 53%,
+      transparent 53%
+    ),
+    conic-gradient(
+      from 45deg,
+      transparent 0 12%,
+      var(--color-accent-soft) 12% 15%,
+      transparent 15% 37%,
+      var(--color-accent-soft) 37% 40%,
+      transparent 40% 100%
+    );
+  content: "";
+  opacity: 0.72;
+  pointer-events: none;
+  transform: rotate(-18deg);
+}
+
+.welcome__damage {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.welcome__claws {
+  position: absolute;
+  top: 16%;
+  right: -6rem;
+  display: block;
+  width: 14rem;
+  height: 32rem;
+  opacity: 1;
+  transform: rotate(-9deg);
+}
+
+.welcome__claws span {
+  position: absolute;
+  top: 0;
+  width: 3.6rem;
+  height: 29rem;
+  background:
+    repeating-linear-gradient(
+      175deg,
+      transparent 0 1.8rem,
+      rgb(255 255 255 / 8%) 1.85rem 1.95rem,
+      transparent 2rem 3.5rem
+    ),
+    linear-gradient(
+      90deg,
+      var(--damage-dark) 0%,
+      color-mix(in srgb, var(--color-accent) 90%, var(--damage-dark)) 32%,
+      color-mix(in srgb, var(--color-accent) 58%, var(--damage-dark)) 68%,
+      var(--damage-dark) 100%
+    );
+  clip-path: polygon(
+    46% 0,
+    72% 10%,
+    55% 23%,
+    78% 35%,
+    57% 48%,
+    70% 62%,
+    47% 76%,
+    59% 100%,
+    32% 87%,
+    41% 72%,
+    20% 57%,
+    42% 43%,
+    21% 27%,
+    36% 12%
+  );
+  filter: drop-shadow(-0.24rem 0 0.08rem var(--color-heading))
+    drop-shadow(0.22rem 0 0.1rem var(--color-accent))
+    drop-shadow(0.42rem 0.55rem 0.4rem rgb(0 0 0 / 82%));
+}
+
+.welcome__claws span:nth-child(1) {
+  left: 0;
+  height: 25rem;
+  margin-top: 3rem;
+  transform: rotate(-4deg) scaleX(0.9);
+}
+
+.welcome__claws span:nth-child(2) {
+  left: 4.4rem;
+  height: 31rem;
+  transform: rotate(-1deg);
+}
+
+.welcome__claws span:nth-child(3) {
+  left: 8.8rem;
+  height: 28rem;
+  clip-path: polygon(
+    42% 0,
+    66% 12%,
+    51% 26%,
+    75% 38%,
+    49% 51%,
+    69% 64%,
+    45% 79%,
+    56% 100%,
+    29% 86%,
+    39% 70%,
+    18% 55%,
+    40% 41%,
+    17% 24%,
+    34% 10%
+  );
+  margin-top: 2rem;
+  transform: rotate(4deg) scaleX(0.92);
+}
+
+.welcome__bullets {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+.welcome__bullets span {
+  position: absolute;
+  width: 4rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 45% 42%,
+    #000000 0 23%,
+    #08090a 25% 32%,
+    var(--color-border-strong) 34% 38%,
+    color-mix(in srgb, var(--damage-metal) 65%, var(--color-accent)) 40% 48%,
+    transparent 51%
+  );
+  filter: drop-shadow(0.35rem 0.5rem 0.4rem rgb(0 0 0 / 65%));
+}
+
+.welcome__bullets span::after {
+  position: absolute;
+  inset: -0.75rem;
+  border-radius: 50%;
+  background: repeating-conic-gradient(
+    from 8deg,
+    transparent 0 19deg,
+    color-mix(in srgb, var(--damage-dark) 72%, transparent) 20deg 21deg,
+    transparent 22deg 43deg
+  );
+  content: "";
+  mask: radial-gradient(
+    circle,
+    transparent 0 43%,
+    #000000 45% 68%,
+    transparent 72%
+  );
+  -webkit-mask: radial-gradient(
+    circle,
+    transparent 0 43%,
+    #000000 45% 68%,
+    transparent 72%
+  );
+}
+
+.welcome__bullets span:nth-child(1) {
+  bottom: 0;
+  left: 5%;
+  transform: rotate(11deg) scale(0.8);
+}
+
+.welcome__bullets span:nth-child(2) {
+  top: 0;
+  left: 16%;
+  transform: rotate(-8deg) scale(1.05);
+}
+
+.welcome__bullets span:nth-child(3) {
+  right: 18%;
+  bottom: 0;
+  transform: rotate(17deg) scale(0.92);
+}
+
+.welcome__bullets span:nth-child(4) {
+  top: 1%;
+  right: 7%;
+  transform: rotate(-14deg) scale(0.72);
+}
+
+.welcome__bullets span:nth-child(5) {
+  right: 0;
+  bottom: 24%;
+  transform: rotate(21deg) scale(1.12);
+}
+
+.welcome__bullets span:nth-child(6) {
+  top: 46%;
+  left: 0;
+  transform: rotate(5deg) scale(0.58);
+}
+
+.welcome__panel > .badge {
+  z-index: 1;
+  grid-area: badge;
+  justify-self: start;
+}
+
+.welcome__signal {
+  position: absolute;
+  z-index: 1;
+  top: var(--space-5);
+  right: var(--space-5);
+  display: flex;
+  gap: var(--space-2);
+}
+
+.welcome__signal span {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 0.8rem var(--color-accent);
+}
+
+.welcome__signal span:nth-child(2) {
+  opacity: 0.55;
+}
+
+.welcome__signal span:nth-child(3) {
+  opacity: 0.2;
+}
+
+.welcome__heading {
+  z-index: 1;
+  display: grid;
+  grid-area: heading;
+  align-self: center;
+  max-width: 52rem;
+  gap: var(--space-4);
+  padding-left: var(--space-5);
+  border-left: 0.35rem solid var(--color-accent);
+}
+
+.welcome__heading h1 {
+  max-width: 10ch;
+  color: var(--title-metal-light);
+  background:
+    repeating-linear-gradient(
+      112deg,
+      transparent 0 0.12em,
+      rgb(255 255 255 / 15%) 0.14em,
+      transparent 0.17em
+    ),
+    linear-gradient(
+      180deg,
+      var(--title-metal-light) 0%,
+      var(--title-metal-mid) 32%,
+      var(--title-metal-accent) 47%,
+      var(--title-metal-light) 51%,
+      var(--title-metal-mid) 68%,
+      var(--title-metal-dark) 100%
+    );
+  background-clip: text;
+  font-size: clamp(3.5rem, 8vw, 7rem);
+  font-weight: 850;
+  line-height: 0.9;
+  paint-order: stroke fill;
+  text-shadow:
+    0 0.025em 0 var(--title-metal-light),
+    0 0.075em 0 var(--title-metal-dark),
+    0 0.12em 0 var(--title-metal-stroke),
+    0 0.18em 0.3em rgb(0 0 0 / 48%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 1px var(--title-metal-stroke);
+}
+
+.welcome__heading p {
+  max-width: 48ch;
+}
+
+.welcome__description {
+  color: var(--color-text);
+  font-size: clamp(1rem, 2vw, 1.3rem);
+}
+
+.welcome__journey {
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+.welcome__call-to-action {
+  color: var(--color-accent);
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.welcome__facts {
+  z-index: 1;
+  display: grid;
+  grid-area: facts;
+  grid-template-columns: 1fr;
+  align-content: center;
+  gap: var(--space-4);
+  margin: 0;
+  padding: var(--space-5);
+  border-left: 1px solid var(--color-accent);
+  background: linear-gradient(
+    135deg,
+    var(--color-accent-soft),
+    transparent 72%
+  );
+}
+
+.welcome__facts div {
+  position: relative;
+  display: grid;
+  min-height: 8.5rem;
+  align-content: start;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  border: 1px solid var(--color-border);
+  border-left: 0.3rem solid var(--color-accent);
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--color-panel) 82%, var(--color-accent));
+  box-shadow: 0 1rem 2rem rgb(0 0 0 / 18%);
+}
+
+.welcome__facts div:nth-child(even) {
+  margin-left: var(--space-5);
+}
+
+.welcome__facts dt {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.welcome__facts dd {
+  order: -1;
+  margin: 0;
+  color: var(--color-accent);
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 5vw, 3.75rem);
+  font-weight: 850;
+  line-height: 1;
+}
+
+.welcome .button {
+  z-index: 1;
+  grid-area: button;
+  min-width: 15rem;
+  justify-self: start;
+}
+
+.pilot-start {
+  display: grid;
+  width: min(100%, 42rem);
+  gap: var(--space-5);
+  padding: clamp(var(--space-6), 6vw, var(--space-8));
+}
+
+.pilot-start h1 {
+  font-size: clamp(2.5rem, 7vw, 5rem);
+}
+
+.pilot-start h1:focus {
+  outline: none;
+}
+
+.meter {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.meter__label {
+  color: var(--color-text);
+  font-size: 0.8rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.meter__track {
+  height: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 999px;
+  background: var(--color-background);
+}
+
+.meter__value {
+  display: block;
+  height: 100%;
+  background: var(--color-accent);
+  box-shadow: 0 0 1rem var(--color-accent);
+}
+
+@media (min-width: 64.01rem) {
+  .welcome__claws {
+    top: -7rem;
+    right: clamp(8rem, 13vw, 13rem);
+    left: auto;
+    transform: rotate(-34deg) scale(1);
+    transform-origin: top right;
+  }
+}
+
+.app-shell .welcome__panel {
+  background:
+    linear-gradient(
+      118deg,
+      color-mix(in srgb, var(--color-panel) 88%, var(--color-panel-raised)) 0
+        54%,
+      var(--color-border-strong) 54.15% 54.4%,
+      transparent 54.55% 100%
+    ),
+    linear-gradient(
+      62deg,
+      transparent 0 67%,
+      color-mix(in srgb, var(--color-accent) 48%, transparent) 67.1% 67.4%,
+      transparent 67.55% 100%
+    ),
+    radial-gradient(
+      ellipse at 72% 32%,
+      var(--color-accent-soft),
+      transparent 48%
+    ),
+    var(--color-panel-raised);
+  border: 1px solid
+    color-mix(in srgb, var(--color-accent) 62%, var(--color-border));
+  border-top: 0.2rem solid var(--color-accent);
+}
+
+.app-shell .welcome__facts div {
+  border-radius: 0;
+  background: linear-gradient(
+    128deg,
+    color-mix(in srgb, var(--color-panel) 90%, var(--color-accent)),
+    var(--color-panel) 62%
+  );
+  clip-path: polygon(0 0, 91% 0, 100% 16%, 100% 100%, 9% 100%, 0 84%);
+}
+
+.app-shell .welcome__panel::after {
+  top: -18%;
+  right: -6%;
+  width: 48%;
+  height: 136%;
+  border: 0;
+  border-radius: 0;
+  background:
+    linear-gradient(
+      138deg,
+      transparent 0 22%,
+      var(--color-accent-soft) 22.2% 25%,
+      transparent 25.2% 48%,
+      color-mix(in srgb, var(--color-border-strong) 35%, transparent) 48.2% 50%,
+      transparent 50.2% 100%
+    ),
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--color-panel-raised) 68%, transparent),
+      transparent 72%
+    );
+  clip-path: polygon(38% 0, 100% 0, 100% 100%, 0 100%, 30% 72%, 8% 48%);
+  opacity: 0.7;
+  transform: skewX(-6deg);
+}
+
+@media (max-width: 64rem) {
+  .welcome {
+    min-height: auto;
+    place-items: start center;
+    padding: 5rem clamp(var(--space-4), 4vw, var(--space-6)) var(--space-6);
+  }
+
+  .welcome__controls {
+    top: var(--space-3);
+    right: var(--space-3);
+  }
+
+  .welcome__panel {
+    width: min(100%, 48rem);
+    min-height: auto;
+    grid-template-areas:
+      "badge"
+      "heading"
+      "facts"
+      "button";
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
+    gap: clamp(var(--space-5), 5vw, var(--space-7));
+    padding: clamp(var(--space-5), 5vw, var(--space-7));
+  }
+
+  .app-shell .welcome__panel::after {
+    top: 0;
+    right: -10%;
+    width: 58%;
+    height: 100%;
+    opacity: 0.45;
+  }
+
+  .welcome__claws {
+    top: 18%;
+    right: -7.5rem;
+    left: auto;
+    opacity: 0.76;
+    transform: rotate(-9deg) scale(0.66);
+    transform-origin: top right;
+  }
+
+  .welcome__signal {
+    display: none;
+  }
+
+  .welcome__heading {
+    width: 100%;
+    max-width: none;
+    align-self: start;
+    padding-left: var(--space-3);
+  }
+
+  .welcome__heading h1 {
+    font-size: clamp(3rem, 13.5vw, 5.5rem);
+  }
+
+  .welcome__facts {
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+    padding: 0;
+    border-left: 0;
+    background: none;
+  }
+
+  .app-shell .welcome__facts div,
+  .app-shell .welcome__facts div:nth-child(even) {
+    min-width: 0;
+    min-height: 7rem;
+    margin-left: 0;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-top: 0.2rem solid var(--color-accent);
+  }
+
+  .welcome__facts dd {
+    font-size: clamp(2rem, 8vw, 3rem);
+  }
+
+  .welcome .button {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 40rem) {
+  .app-shell {
+    background-position:
+      35% 0,
+      70% 0,
+      72% 18%,
+      center;
+    background-size:
+      30rem 34rem,
+      24rem 28rem,
+      42rem 34rem,
+      auto;
+  }
+
+  .welcome {
+    min-height: 100vh;
+    min-height: 100dvh;
+    place-items: center;
+    padding-top: 4.75rem;
+  }
+
+  .welcome__claws {
+    top: -3.5rem;
+    right: 3rem;
+    opacity: 0.92;
+    transform: rotate(-42deg) scale(0.58);
+  }
+
+  .welcome__bullets span {
+    width: 2.75rem;
+  }
+
+  .welcome__bullets span:nth-child(1) {
+    bottom: 1rem;
+    left: -0.7rem;
+    transform: rotate(11deg) scale(0.72);
+  }
+
+  .welcome__bullets span:nth-child(2) {
+    top: 0.6rem;
+    left: 4%;
+    transform: rotate(-8deg) scale(0.88);
+  }
+
+  .welcome__bullets span:nth-child(3) {
+    right: 18%;
+    bottom: 0.25rem;
+    transform: rotate(17deg) scale(0.8);
+  }
+
+  .welcome__bullets span:nth-child(4) {
+    top: 1rem;
+    right: 48%;
+    transform: rotate(-14deg) scale(0.62);
+  }
+
+  .welcome__bullets span:nth-child(5) {
+    right: -0.8rem;
+    bottom: 18%;
+    transform: rotate(21deg) scale(0.86);
+  }
+
+  .welcome__bullets span:nth-child(6) {
+    top: 38%;
+    left: -0.8rem;
+    transform: rotate(5deg) scale(0.6);
+  }
+
+  .welcome__panel {
+    min-height: auto;
+    gap: var(--space-5);
+    grid-template-rows: auto;
+    padding: clamp(var(--space-4), 5vw, var(--space-5));
+    border-radius: var(--radius-medium);
+  }
+
+  .welcome__panel > .badge {
+    min-height: auto;
+    justify-self: center;
+    gap: var(--space-2);
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    font-size: 0.55rem;
+    letter-spacing: 0.16em;
+    opacity: 0.72;
+  }
+
+  .welcome__panel > .badge::before,
+  .welcome__panel > .badge::after {
+    width: 1.25rem;
+    height: 1px;
+    background: var(--color-accent);
+    content: "";
+  }
+
+  .app-shell .welcome__panel::after {
+    top: auto;
+    right: -20%;
+    bottom: -12%;
+    width: 75%;
+    height: 48%;
+    opacity: 0.28;
+  }
+
+  .welcome__heading {
+    align-self: center;
+    justify-items: center;
+    gap: var(--space-3);
+    padding-left: 0;
+    border-left: 0;
+    text-align: center;
+  }
+
+  .welcome__heading h1 {
+    max-width: 100%;
+    font-size: clamp(2.75rem, 13.5vw, 4rem);
+  }
+
+  .welcome__heading p {
+    max-width: 34rem;
+  }
+
+  .welcome__description {
+    font-size: 0.95rem;
+  }
+
+  .welcome__journey {
+    font-size: 0.85rem;
+  }
+
+  .welcome__call-to-action {
+    font-size: 0.75rem;
+  }
+
+  .welcome__facts {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-2);
+    overflow: visible;
+    border: 0;
+    background: none;
+  }
+
+  .app-shell .welcome__facts div,
+  .app-shell .welcome__facts div:nth-child(even) {
+    min-height: 4.75rem;
+    place-content: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-1);
+    border: 1px solid var(--color-border);
+    border-top: 0.15rem solid var(--color-accent);
+    border-radius: 0.35rem;
+    background: var(--color-panel);
+    clip-path: none;
+    text-align: center;
+  }
+
+  .welcome__facts dd {
+    font-size: clamp(1.5rem, 7vw, 2rem);
+  }
+
+  .welcome__facts dt {
+    overflow-wrap: anywhere;
+    font-size: clamp(0.48rem, 2vw, 0.62rem);
+    letter-spacing: 0.02em;
+    line-height: 1.15;
+  }
+}
+
+@media (max-width: 22rem) {
+  .welcome {
+    padding-inline: var(--space-3);
+  }
+
+  .welcome__panel {
+    gap: var(--space-5);
+    padding: var(--space-4);
+    border-radius: var(--radius-medium);
+  }
+
+  .welcome__heading h1 {
+    font-size: clamp(2.5rem, 14vw, 3.25rem);
+  }
+
+  .welcome__facts dt {
+    font-size: 0.46rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/locales/en/interface.json
+++ b/src/locales/en/interface.json
@@ -12,5 +12,33 @@
   "factions": {
     "guylos": "Guylos Empire",
     "helic": "Helic Republic"
+  },
+  "pilotCreation": {
+    "badge": "Pilot file unlocked",
+    "description": "Pilot configuration will continue here in the next mission update.",
+    "title": "Your career begins now"
+  },
+  "welcome": {
+    "badge": "Pilot recruitment transmission",
+    "callToAction": "Become a legend or fade into obscurity.",
+    "colorMode": {
+      "light": "Light mode"
+    },
+    "description": "On planet Zi, beyond the Milky Way, steel Zoids possess outstanding combat capabilities.",
+    "facts": {
+      "decisions": "decisions",
+      "factions": "factions",
+      "label": "Career scope",
+      "paths": "possible paths",
+      "wars": "war to decide"
+    },
+    "journey": "In this world, every soldier starts at the bottom and makes the decisions that will forge their path to the top. This is your story.",
+    "language": {
+      "en": "English",
+      "es": "Spanish",
+      "label": "Language"
+    },
+    "start": "Begin your career",
+    "title": "Scars of Steel"
   }
 }

--- a/src/locales/es/interface.json
+++ b/src/locales/es/interface.json
@@ -12,5 +12,33 @@
   "factions": {
     "guylos": "Imperio de Guylos",
     "helic": "República de Helic"
+  },
+  "pilotCreation": {
+    "badge": "Expediente de piloto desbloqueado",
+    "description": "La configuración del piloto continuará aquí en la próxima actualización de misión.",
+    "title": "Tu carrera comienza ahora"
+  },
+  "welcome": {
+    "badge": "Transmisión de reclutamiento",
+    "callToAction": "Conviértete en leyenda o queda en el olvido.",
+    "colorMode": {
+      "light": "Modo claro"
+    },
+    "description": "En el planeta Zi, más allá de la Vía Láctea, existen Zoids de acero con destacada capacidad de combate.",
+    "facts": {
+      "decisions": "decisiones",
+      "factions": "facciones",
+      "label": "Alcance de la carrera",
+      "paths": "caminos posibles",
+      "wars": "guerra por decidir"
+    },
+    "journey": "En este mundo, cada soldado comienza desde abajo y toma las decisiones que forjarán su camino hasta la cima. Esta es tu historia.",
+    "language": {
+      "en": "Inglés",
+      "es": "Español",
+      "label": "Idioma"
+    },
+    "start": "Inicia tu carrera",
+    "title": "Cicatrices de Acero"
   }
 }

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -1,15 +1,149 @@
-import { render, screen } from "@testing-library/react";
-import { expect, test } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { App } from "../app/App";
+import { WelcomeScreen } from "../app/WelcomeScreen";
+import { i18n } from "../i18n";
 
-test("shows the localized introduction", () => {
+const defaultColorMode = "dark";
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.lang = "en";
+  void i18n.changeLanguage("en");
+});
+
+describe("welcome screen", () => {
+  test("shows the localized career scope", () => {
+    render(<App />);
+
+    const heading = screen.getByRole("heading", { name: "Scars of Steel" });
+    expect(heading).toBeInTheDocument();
+    expect(heading.closest(".app-shell")).toHaveAttribute(
+      "data-color-mode",
+      "dark",
+    );
+    expect(
+      screen.getByText(
+        "On planet Zi, beyond the Milky Way, steel Zoids possess outstanding combat capabilities.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "In this world, every soldier starts at the bottom and makes the decisions that will forge their path to the top. This is your story.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Become a legend or fade into obscurity."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2").nextElementSibling).toHaveTextContent(
+      "factions",
+    );
+    expect(screen.getByText("5").nextElementSibling).toHaveTextContent(
+      "decisions",
+    );
+    expect(screen.getByText("21").nextElementSibling).toHaveTextContent(
+      "possible paths",
+    );
+    expect(screen.getByText("1").nextElementSibling).toHaveTextContent(
+      "war to decide",
+    );
+  });
+
+  test("shows Spanish content", async () => {
+    await i18n.changeLanguage("es");
+
+    render(
+      <WelcomeScreen
+        colorMode={defaultColorMode}
+        onColorModeChange={() => undefined}
+        onStart={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Cicatrices de Acero" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "En el planeta Zi, más allá de la Vía Láctea, existen Zoids de acero con destacada capacidad de combate.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "En este mundo, cada soldado comienza desde abajo y toma las decisiones que forjarán su camino hasta la cima. Esta es tu historia.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Conviértete en leyenda o queda en el olvido."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("guerra por decidir")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Inicia tu carrera" }),
+    ).toBeInTheDocument();
+  });
+
+  test("starts the flow only once", () => {
+    const onStart = vi.fn();
+
+    render(
+      <WelcomeScreen
+        colorMode={defaultColorMode}
+        onColorModeChange={() => undefined}
+        onStart={onStart}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Begin your career" });
+    button.focus();
+    expect(button).toHaveFocus();
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(button).toBeDisabled();
+  });
+
+  test("moves focus to pilot creation after starting", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Begin your career" }));
+
+    const heading = screen.getByRole("heading", {
+      name: "Your career begins now",
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveFocus();
+  });
+});
+
+test("changes between dark and light modes", () => {
   render(<App />);
 
+  const colorModeSwitch = screen.getByRole("switch", { name: "Light mode" });
+  expect(colorModeSwitch).not.toBeChecked();
+  fireEvent.click(colorModeSwitch);
+
+  const app = screen
+    .getByRole("heading", { name: "Scars of Steel" })
+    .closest(".app-shell");
+  expect(colorModeSwitch).toBeChecked();
+  expect(app).toHaveAttribute("data-color-mode", "light");
+});
+
+test("changes the interface language", async () => {
+  render(<App />);
+
+  const languageSelector = screen.getByRole("group", { name: "Language" });
+  const englishButton = screen.getByRole("button", { name: "English" });
+  expect(languageSelector).toBeInTheDocument();
+  expect(englishButton).toHaveAttribute("aria-pressed", "true");
+
+  fireEvent.click(screen.getByRole("button", { name: "Spanish" }));
+
   expect(
-    screen.getByRole("heading", { name: "Scars of Steel" }),
+    await screen.findByRole("heading", { name: "Cicatrices de Acero" }),
   ).toBeInTheDocument();
-  expect(
-    screen.getByText("Your career as a pilot is about to begin."),
-  ).toBeInTheDocument();
+  expect(document.documentElement).toHaveAttribute("lang", "es");
 });


### PR DESCRIPTION
## Summary

- Add a localized welcome screen in English and Spanish.
- Add the transition from the welcome screen to pilot creation.
- Add reusable button, panel, badge, and meter components.
- Add accessible language and color mode controls.
- Add responsive layouts for desktop, tablet, and mobile.
- Add a military anime visual system with light and dark modes.
- Add steel, claw, and bullet damage effects using CSS.
- Show 2 factions, 5 decisions, 21 possible paths, and 1 war to decide.
- Add visible focus states and reduced-motion support.
- Add tests for localization, accessibility, controls, statistics, and navigation.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:run` — 62 tests passed
- `npm run build`

Closes #6
