### PR TITLE
Persist careers, preferences, and service records

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getEligibleEventIds, selectEvent } from "../domain/eventPools";
 import { getEvent } from "../domain/events";
@@ -18,9 +18,19 @@ import type {
 } from "../domain/types";
 import { selectTitle } from "../domain/titles";
 import { resolveYear } from "../domain/year";
-import { AppControls, type ColorMode } from "./AppControls";
+import { AppControls } from "./AppControls";
+import {
+  loadColorModePreference,
+  saveColorModePreference,
+} from "./colorModeStorage";
 import { DecisionScreen } from "./DecisionScreen";
 import { FinalScreen } from "./FinalScreen";
+import {
+  type CompletedGame,
+  createCompletedGame,
+  loadGameData,
+  saveGameData,
+} from "./gameStorage";
 import {
   PilotCreationScreen,
   type PilotConfiguration,
@@ -29,21 +39,60 @@ import { ScreenTransition } from "./ScreenTransition";
 import { WelcomeScreen } from "./WelcomeScreen";
 
 export function App() {
-  const [colorMode, setColorMode] = useState<ColorMode>("dark");
-  const [gameState, setGameState] = useState<GameState>({
-    screen: "welcome",
+  const [appState, setAppState] = useState<{
+    completedGames: readonly CompletedGame[];
+    gameState: GameState;
+  }>(() => {
+    const storedData = loadGameData();
+
+    return {
+      completedGames: storedData.completedGames,
+      gameState: storedData.activeGame ?? ({ screen: "welcome" } as const),
+    };
   });
+  const [colorMode, setColorMode] = useState(loadColorModePreference);
   const [reducedMotion, setReducedMotion] = useState(false);
   const hasResolvedDecisionRef = useRef(false);
   const hasClosedYearRef = useRef(false);
   const hasCreatedPilotRef = useRef(false);
   const randomRef = useRef(createSecureRandomGenerator());
+  const { gameState } = appState;
+
+  useEffect(() => {
+    saveGameData({
+      activeGame:
+        appState.gameState.screen === "event" ||
+        appState.gameState.screen === "pilot-creation"
+          ? appState.gameState
+          : null,
+      completedGames: appState.completedGames,
+      version: 2,
+    });
+  }, [appState]);
+
+  useEffect(() => {
+    saveColorModePreference(colorMode);
+  }, [colorMode]);
+
+  function updateGameState(
+    update: GameState | ((currentState: GameState) => GameState),
+  ) {
+    setAppState((currentState) => ({
+      ...currentState,
+      gameState:
+        typeof update === "function" ? update(currentState.gameState) : update,
+    }));
+  }
+
+  function openCompletedGame(game: CompletedGame) {
+    updateGameState(game.state);
+  }
 
   function startGame() {
     hasClosedYearRef.current = false;
     hasResolvedDecisionRef.current = false;
     hasCreatedPilotRef.current = false;
-    setGameState((currentState) =>
+    updateGameState((currentState) =>
       currentState.screen === "welcome"
         ? {
             draft: { aspiration: null, faction: null, name: "" },
@@ -54,7 +103,7 @@ export function App() {
   }
 
   function changePilotDraft(draft: PilotCreationGameState["draft"]) {
-    setGameState((currentState) =>
+    updateGameState((currentState) =>
       currentState.screen === "pilot-creation"
         ? { ...currentState, draft }
         : currentState,
@@ -77,7 +126,7 @@ export function App() {
       randomRef.current,
     );
 
-    setGameState({
+    updateGameState({
       eventId: event.id,
       history,
       phase: "choosing",
@@ -105,7 +154,7 @@ export function App() {
 
     hasResolvedDecisionRef.current = true;
     hasClosedYearRef.current = false;
-    setGameState({
+    updateGameState({
       eventId: gameState.eventId,
       history: gameState.history,
       ...(result.resolution.kind === "chance"
@@ -120,7 +169,7 @@ export function App() {
   }
 
   function revealOutcome() {
-    setGameState((currentState) =>
+    updateGameState((currentState) =>
       currentState.screen === "event" && currentState.phase === "animating"
         ? {
             eventId: currentState.eventId,
@@ -161,14 +210,24 @@ export function App() {
     );
 
     if (endReason) {
-      setGameState({
+      const finalState = {
         endReason,
         history,
         nicknameId: selectNickname(pilot.stats, randomRef.current),
         pilot,
         screen: "final",
         titleId: selectTitle(pilot, history, endReason),
-      });
+      } as const;
+
+      setAppState((currentState) => ({
+        completedGames: [
+          createCompletedGame(finalState),
+          ...currentState.completedGames.filter(
+            ({ state }) => state.pilot.id !== pilot.id,
+          ),
+        ],
+        gameState: finalState,
+      }));
       return;
     }
 
@@ -176,7 +235,7 @@ export function App() {
     hasResolvedDecisionRef.current = false;
     const event = selectEvent(eligibleEventIds, randomRef.current);
 
-    setGameState({
+    updateGameState({
       eventId: event.id,
       history,
       phase: "choosing",
@@ -189,7 +248,7 @@ export function App() {
     hasClosedYearRef.current = false;
     hasCreatedPilotRef.current = false;
     hasResolvedDecisionRef.current = false;
-    setGameState({ screen: "welcome" });
+    updateGameState({ screen: "welcome" });
   }
 
   const faction =
@@ -214,7 +273,9 @@ export function App() {
       >
         {gameState.screen === "welcome" ? (
           <WelcomeScreen
+            completedGames={appState.completedGames}
             onReducedMotionChange={setReducedMotion}
+            onSelectGame={openCompletedGame}
             onStart={startGame}
             reducedMotion={reducedMotion}
           />
@@ -229,6 +290,7 @@ export function App() {
         ) : gameState.screen === "event" ? (
           <DecisionScreen
             event={getEvent(gameState.eventId)}
+            onAbandon={restartGame}
             onCloseYear={closeYear}
             onDecision={chooseDecision}
             onReducedMotionChange={setReducedMotion}

--- a/src/app/AppControls.tsx
+++ b/src/app/AppControls.tsx
@@ -1,10 +1,14 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-export type ColorMode = "dark" | "light";
-type Language = "en" | "es";
+import {
+  saveLanguagePreference,
+  supportedLanguages,
+  type Language,
+} from "../i18n";
+import type { ColorMode } from "./colorModeStorage";
 
-const languages: Language[] = ["en", "es"];
+export type { ColorMode } from "./colorModeStorage";
 
 interface AppControlsProps {
   colorMode: ColorMode;
@@ -22,6 +26,7 @@ export function AppControls({
   }, [i18n.resolvedLanguage]);
 
   function changeLanguage(language: Language) {
+    saveLanguagePreference(language);
     void i18n.changeLanguage(language);
   }
 
@@ -36,7 +41,7 @@ export function AppControls({
         className="language-selector"
         role="group"
       >
-        {languages.map((language) => (
+        {supportedLanguages.map((language) => (
           <button
             aria-label={t(`welcome.language.${language}`)}
             aria-pressed={i18n.resolvedLanguage === language}

--- a/src/app/DecisionOutcomeScreen.tsx
+++ b/src/app/DecisionOutcomeScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type CSSProperties } from "react";
+import { useEffect, useId, useRef, useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
 import { achievementNameKeys } from "../domain/achievements";
@@ -32,6 +32,7 @@ const zoidFallbackIcon = "◇";
 
 interface DecisionOutcomeScreenProps {
   event: DecisionEvent;
+  onAbandon: () => void;
   onCloseYear: () => void;
   result: ResolvedYear;
   titleId: string;
@@ -39,10 +40,13 @@ interface DecisionOutcomeScreenProps {
 
 export function DecisionOutcomeScreen({
   event,
+  onAbandon,
   onCloseYear,
   result,
   titleId,
 }: DecisionOutcomeScreenProps) {
+  const [showAbandonDialog, setShowAbandonDialog] = useState(false);
+  const abandonButtonRef = useRef<HTMLButtonElement>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const { t } = useTranslation("interface");
   const decision = event.decisions.find(
@@ -63,6 +67,11 @@ export function DecisionOutcomeScreen({
   useEffect(() => {
     headingRef.current?.focus();
   }, []);
+
+  function cancelAbandon() {
+    setShowAbandonDialog(false);
+    abandonButtonRef.current?.focus();
+  }
 
   return (
     <section
@@ -181,14 +190,82 @@ export function DecisionOutcomeScreen({
         </section>
       </div>
 
-      <button
-        className="button button--primary"
-        onClick={onCloseYear}
-        type="button"
-      >
-        {t("outcomeScreen.close")}
-      </button>
+      <div className="outcome-screen__actions">
+        <button
+          className="button button--secondary"
+          onClick={() => setShowAbandonDialog(true)}
+          ref={abandonButtonRef}
+          type="button"
+        >
+          {t("outcomeScreen.abandon")}
+        </button>
+        <button
+          className="button button--primary"
+          onClick={onCloseYear}
+          type="button"
+        >
+          {t("outcomeScreen.close")}
+        </button>
+      </div>
+      {showAbandonDialog ? (
+        <AbandonDialog onCancel={cancelAbandon} onConfirm={onAbandon} />
+      ) : null}
     </section>
+  );
+}
+
+interface AbandonDialogProps {
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function AbandonDialog({ onCancel, onConfirm }: AbandonDialogProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const descriptionId = useId();
+  const titleId = useId();
+  const { t } = useTranslation("interface");
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="abandon-dialog__backdrop"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          onCancel();
+        }
+      }}
+    >
+      <section
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="abandon-dialog"
+        role="alertdialog"
+      >
+        <h2 id={titleId}>{t("outcomeScreen.abandonDialog.title")}</h2>
+        <p id={descriptionId}>{t("outcomeScreen.abandonDialog.description")}</p>
+        <div>
+          <button
+            className="button"
+            onClick={onCancel}
+            ref={cancelButtonRef}
+            type="button"
+          >
+            {t("outcomeScreen.abandonDialog.cancel")}
+          </button>
+          <button
+            className="button button--primary"
+            onClick={onConfirm}
+            type="button"
+          >
+            {t("outcomeScreen.abandonDialog.confirm")}
+          </button>
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/src/app/DecisionScreen.tsx
+++ b/src/app/DecisionScreen.tsx
@@ -11,6 +11,7 @@ import { Panel } from "./UiPrimitives";
 
 interface DecisionScreenProps {
   event: DecisionEvent;
+  onAbandon: () => void;
   onCloseYear: () => void;
   onDecision: (decision: Decision) => void;
   onReducedMotionChange: (reducedMotion: boolean) => void;
@@ -21,6 +22,7 @@ interface DecisionScreenProps {
 
 export function DecisionScreen({
   event,
+  onAbandon,
   onCloseYear,
   onDecision,
   onReducedMotionChange,
@@ -65,6 +67,7 @@ export function DecisionScreen({
             ) : (
               <DecisionOutcomeScreen
                 event={event}
+                onAbandon={onAbandon}
                 onCloseYear={onCloseYear}
                 result={state.result}
                 titleId={phaseTitleId}

--- a/src/app/WelcomeScreen.tsx
+++ b/src/app/WelcomeScreen.tsx
@@ -1,7 +1,14 @@
 import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { militaryRankNameKeys, specialRankNameKeys } from "../domain/pilot";
+import { getRankInsignia } from "../domain/ranks";
+import { getTitleDefinition } from "../domain/titles";
+import { getZoid } from "../domain/zoids";
+import { translate } from "../i18n";
 import { AnimationToggle } from "./AppControls";
+import type { CompletedGame } from "./gameStorage";
+import { RankInsignia } from "./RankInsignia";
 import { Badge, Button, Panel } from "./UiPrimitives";
 
 const welcomeFacts = {
@@ -10,15 +17,21 @@ const welcomeFacts = {
   paths: 21,
   wars: 1,
 } as const;
+const serviceRecordIcons = { fame: "★", potential: "⚡" } as const;
+const zoidFallbackIcon = "◇";
 
 interface WelcomeScreenProps {
+  completedGames: readonly CompletedGame[];
   onReducedMotionChange: (reducedMotion: boolean) => void;
+  onSelectGame: (game: CompletedGame) => void;
   onStart: () => void;
   reducedMotion: boolean;
 }
 
 export function WelcomeScreen({
+  completedGames,
   onReducedMotionChange,
+  onSelectGame,
   onStart,
   reducedMotion,
 }: WelcomeScreenProps) {
@@ -39,7 +52,10 @@ export function WelcomeScreen({
 
   return (
     <main className="screen welcome">
-      <Panel className="welcome__panel" labelledBy={titleId}>
+      <Panel
+        className={`welcome__panel${completedGames.length > 0 ? " welcome__panel--records" : ""}`}
+        labelledBy={titleId}
+      >
         <AnimationToggle
           onReducedMotionChange={onReducedMotionChange}
           reducedMotion={reducedMotion}
@@ -84,7 +100,125 @@ export function WelcomeScreen({
         <Button disabled={started} onClick={handleStart}>
           {t("welcome.start")}
         </Button>
+        <ServiceRecords
+          completedGames={completedGames}
+          onSelectGame={onSelectGame}
+        />
       </Panel>
     </main>
+  );
+}
+
+interface ServiceRecordsProps {
+  completedGames: readonly CompletedGame[];
+  onSelectGame: (game: CompletedGame) => void;
+}
+
+function ServiceRecords({ completedGames, onSelectGame }: ServiceRecordsProps) {
+  const { t } = useTranslation("interface");
+
+  if (completedGames.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="service-records">
+      <h2>{t("welcome.serviceRecords.title")}</h2>
+      <ul>
+        {completedGames.map((game) => (
+          <ServiceRecord
+            game={game}
+            key={game.state.pilot.id}
+            onSelect={onSelectGame}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface ServiceRecordProps {
+  game: CompletedGame;
+  onSelect: (game: CompletedGame) => void;
+}
+
+function ServiceRecord({ game, onSelect }: ServiceRecordProps) {
+  const { t } = useTranslation("interface");
+  const { pilot } = game.state;
+  const rank = translate(
+    pilot.career.specialRank
+      ? specialRankNameKeys[pilot.career.specialRank]
+      : militaryRankNameKeys[pilot.career.militaryRank],
+  );
+  const title = getTitleDefinition(game.state.titleId);
+  const titleName = translate(title.nameKey);
+  const zoid = pilot.zoids ? getZoid(pilot.zoids.signatureId) : null;
+  const zoidName = zoid
+    ? translate(zoid.nameKey)
+    : t("careerStatus.unassigned");
+
+  return (
+    <li>
+      <button
+        aria-label={t("welcome.serviceRecords.open", { name: pilot.name })}
+        className="service-records__row"
+        data-faction={pilot.faction}
+        onClick={() => onSelect(game)}
+        type="button"
+      >
+        <span
+          aria-label={titleName}
+          className="service-records__title"
+          title={titleName}
+        >
+          <img alt="" src={title.iconPath} />
+        </span>
+        <strong className="service-records__name" title={pilot.name}>
+          {pilot.name}
+        </strong>
+        <span aria-label={rank} className="service-records__rank" title={rank}>
+          <RankInsignia insignia={getRankInsignia(pilot.career.militaryRank)} />
+          <small>{rank}</small>
+        </span>
+        <span
+          aria-label={t("careerStatus.zoidLabel", { name: zoidName })}
+          className="service-records__zoid"
+        >
+          {zoid?.imagePath ? (
+            <img alt="" src={zoid.imagePath} />
+          ) : (
+            <span aria-hidden="true">{zoidFallbackIcon}</span>
+          )}
+          <small>{zoidName}</small>
+        </span>
+        <ServiceRecordMetric
+          icon={serviceRecordIcons.potential}
+          label={t("careerStatus.potentialLabel", { value: pilot.potential })}
+          value={pilot.potential}
+        />
+        <ServiceRecordMetric
+          icon={serviceRecordIcons.fame}
+          label={t("careerStatus.fameLabel", {
+            value: pilot.career.fame,
+          })}
+          value={pilot.career.fame}
+        />
+      </button>
+    </li>
+  );
+}
+
+interface ServiceRecordMetricProps {
+  icon: string;
+  label: string;
+  value: number;
+}
+
+function ServiceRecordMetric({ icon, label, value }: ServiceRecordMetricProps) {
+  return (
+    <span aria-label={label} className="service-records__metric">
+      <span aria-hidden="true">{icon}</span>
+      <strong>{value}</strong>
+    </span>
   );
 }

--- a/src/app/colorModeStorage.ts
+++ b/src/app/colorModeStorage.ts
@@ -1,0 +1,25 @@
+export type ColorMode = "dark" | "light";
+
+export const colorModeStorageKey = "scars-of-steel:color-mode";
+
+export function loadColorModePreference(): ColorMode {
+  try {
+    const colorMode = window.localStorage.getItem(colorModeStorageKey);
+
+    if (colorMode === "dark" || colorMode === "light") {
+      return colorMode;
+    }
+  } catch {
+    // Use the default theme when storage is unavailable.
+  }
+
+  return "dark";
+}
+
+export function saveColorModePreference(colorMode: ColorMode) {
+  try {
+    window.localStorage.setItem(colorModeStorageKey, colorMode);
+  } catch {
+    // Keep the selected theme in memory when storage is unavailable.
+  }
+}

--- a/src/app/gameStorage.ts
+++ b/src/app/gameStorage.ts
@@ -1,0 +1,386 @@
+import { getEvent, getOutcome } from "../domain/events";
+import { getNicknameKey } from "../domain/nicknames";
+import { getTitleDefinition } from "../domain/titles";
+import { getZoid } from "../domain/zoids";
+import type {
+  ActiveGameState,
+  AppliedChange,
+  CareerEndReason,
+  CareerHistory,
+  EventGameState,
+  FinalGameState,
+  Pilot,
+  PilotCreationGameState,
+  ResolvedYear,
+  TitleId,
+  ZoidId,
+} from "../domain/types";
+
+const gameStorageKey = "scars-of-steel:game-data";
+const schemaVersion = 2;
+
+const aspirations = ["commander", "shadow", "war-hero", "zoid-ace"] as const;
+const careerEndReasons = [
+  "dead",
+  "disappeared",
+  "no-eligible-events",
+  "non-operational",
+  "retired",
+  "war-lost",
+  "war-won",
+] as const satisfies readonly CareerEndReason[];
+const factions = ["guylos", "helic"] as const;
+const militaryRanks = [
+  "cadet",
+  "captain",
+  "commander",
+  "corporal",
+  "general",
+  "lieutenant",
+  "major",
+  "sergeant",
+  "soldier",
+] as const;
+const specialRanks = [
+  "blitz-orbit",
+  "eizen-dragoons",
+  "leo-master",
+  "machinery-four",
+  "prozen-knight",
+  "tactical-master",
+  "traitor",
+] as const;
+const statNames = [
+  "charisma",
+  "piloting",
+  "strength",
+  "synchrony",
+  "tactics",
+  "technique",
+] as const;
+const warIntensities = ["active", "fierce", "low"] as const;
+
+export interface CompletedGame {
+  state: FinalGameState;
+}
+
+export interface StoredGameData {
+  activeGame: ActiveGameState | null;
+  completedGames: readonly CompletedGame[];
+  version: typeof schemaVersion;
+}
+
+export function createCompletedGame(state: FinalGameState): CompletedGame {
+  return { state };
+}
+
+export function createEmptyGameData(): StoredGameData {
+  return { activeGame: null, completedGames: [], version: schemaVersion };
+}
+
+export function loadGameData(): StoredGameData {
+  try {
+    const storedValue = window.localStorage.getItem(gameStorageKey);
+    const value: unknown = storedValue ? JSON.parse(storedValue) : null;
+
+    return isStoredGameData(value) ? value : createEmptyGameData();
+  } catch {
+    return createEmptyGameData();
+  }
+}
+
+export function saveGameData(data: StoredGameData): void {
+  try {
+    window.localStorage.setItem(gameStorageKey, JSON.stringify(data));
+  } catch {
+    // Storage must not block an in-memory game.
+  }
+}
+
+function isStoredGameData(value: unknown): value is StoredGameData {
+  return (
+    isRecord(value) &&
+    value.version === schemaVersion &&
+    (value.activeGame === null || isActiveGame(value.activeGame)) &&
+    Array.isArray(value.completedGames) &&
+    value.completedGames.every(isCompletedGame)
+  );
+}
+
+function isActiveGame(value: unknown): value is ActiveGameState {
+  return (
+    isPilotCreationGame(value) ||
+    (isRecord(value) && value.screen === "event" && isEventGame(value))
+  );
+}
+
+function isPilotCreationGame(value: unknown): value is PilotCreationGameState {
+  return (
+    isRecord(value) &&
+    value.screen === "pilot-creation" &&
+    isRecord(value.draft) &&
+    isOptionalMember(value.draft.aspiration, aspirations) &&
+    isOptionalMember(value.draft.faction, factions) &&
+    typeof value.draft.name === "string"
+  );
+}
+
+function isEventGame(value: Record<string, unknown>): boolean {
+  if (
+    !isKnownEventId(value.eventId) ||
+    !isCareerHistory(value.history) ||
+    !isPilot(value.pilot)
+  ) {
+    return false;
+  }
+
+  return value.phase === "choosing"
+    ? value.result === undefined
+    : (value.phase === "animating" || value.phase === "outcome") &&
+        isResolvedYear(value.result, value.eventId);
+}
+
+function isCompletedGame(value: unknown): value is CompletedGame {
+  return isRecord(value) && isFinalGameState(value.state);
+}
+
+function isFinalGameState(value: unknown): value is FinalGameState {
+  if (
+    !isRecord(value) ||
+    value.screen !== "final" ||
+    !isMember(value.endReason, careerEndReasons) ||
+    !isCareerHistory(value.history) ||
+    !isPilot(value.pilot) ||
+    typeof value.nicknameId !== "string" ||
+    !value.nicknameId.startsWith("nickname:") ||
+    typeof value.titleId !== "string" ||
+    !value.titleId.startsWith("title:")
+  ) {
+    return false;
+  }
+
+  try {
+    getNicknameKey(value.nicknameId as `nickname:${string}`);
+    getTitleDefinition(value.titleId as TitleId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCareerHistory(value: unknown): value is CareerHistory {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.achievementIds) &&
+    value.achievementIds.every(
+      (id) => typeof id === "string" && id.startsWith("achievement:"),
+    ) &&
+    isCareerBattles(value.battles) &&
+    Array.isArray(value.completedEventIds) &&
+    value.completedEventIds.every(isKnownEventId)
+  );
+}
+
+function isCareerBattles(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    ["losses", "participated", "wins"].every((key) =>
+      isNonNegativeInteger(value[key]),
+    )
+  );
+}
+
+function isResolvedYear(
+  value: unknown,
+  eventId: EventGameState["eventId"],
+): value is ResolvedYear {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.achievementIds) ||
+    !value.achievementIds.every(
+      (id) => typeof id === "string" && id.startsWith("achievement:"),
+    ) ||
+    !isBattleRecord(value.battleRecord) ||
+    !Array.isArray(value.changes) ||
+    !value.changes.every(isAppliedChange) ||
+    !isPilot(value.pilotAfter) ||
+    !isPilot(value.pilotBefore) ||
+    !isResolution(value.resolution) ||
+    !Array.isArray(value.zoidIds) ||
+    !value.zoidIds.every(isKnownZoidId) ||
+    !isRecord(value.outcome) ||
+    typeof value.outcome.id !== "string"
+  ) {
+    return false;
+  }
+
+  try {
+    const outcome = getOutcome(
+      getEvent(eventId),
+      value.outcome.id as `outcome:${string}`,
+    );
+
+    return JSON.stringify(value.outcome) === JSON.stringify(outcome);
+  } catch {
+    return false;
+  }
+}
+
+function isBattleRecord(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    ["assigned", "available", "losses", "participated", "wins"].every((key) =>
+      isNonNegativeInteger(value[key]),
+    ) &&
+    ["injured", "killed", "zoidDamaged", "zoidDestroyed"].every(
+      (key) => typeof value[key] === "boolean",
+    )
+  );
+}
+
+function isAppliedChange(value: unknown): value is AppliedChange {
+  if (
+    !isRecord(value) ||
+    !isBoundedValue(value.current) ||
+    !isBoundedValue(value.previous)
+  ) {
+    return false;
+  }
+
+  switch (value.target) {
+    case "career-indicator":
+      return value.indicator === "faction-trust" || value.indicator === "fame";
+    case "potential":
+      return true;
+    case "stat":
+      return isMember(value.stat, statNames);
+    case "war-state":
+      return isMember(value.faction, factions);
+    default:
+      return false;
+  }
+}
+
+function isResolution(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.decisionId === "string" &&
+    typeof value.outcomeId === "string" &&
+    (value.kind === "safe" ||
+      (value.kind === "chance" &&
+        isBoundedValue(value.adjustedSuccessChance) &&
+        isBoundedValue(value.roll) &&
+        (value.result === "failure" || value.result === "success")))
+  );
+}
+
+function isPilot(value: unknown): value is Pilot {
+  return (
+    isRecord(value) &&
+    Number.isSafeInteger(value.age) &&
+    isMember(value.aspiration, aspirations) &&
+    isBoundedValue(value.basePotential) &&
+    isRecord(value.career) &&
+    isBoundedValue(value.career.factionTrust) &&
+    isBoundedValue(value.career.fame) &&
+    isMember(value.career.militaryRank, militaryRanks) &&
+    isOptionalMember(value.career.specialRank, specialRanks) &&
+    isWarState(value.career.warState) &&
+    (value.condition === "active" ||
+      value.condition === "dead" ||
+      value.condition === "injured") &&
+    isMember(value.faction, factions) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    isBoundedValue(value.potential) &&
+    isStats(value.stats) &&
+    isPilotZoids(value.zoids)
+  );
+}
+
+function isStats(value: unknown): boolean {
+  return (
+    isRecord(value) && statNames.every((stat) => isBoundedValue(value[stat]))
+  );
+}
+
+function isWarState(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isMember(value.intensity, warIntensities) &&
+    Array.isArray(value.sides) &&
+    value.sides.length === 2 &&
+    value.sides.every(
+      (side) =>
+        isRecord(side) &&
+        isBoundedValue(side.control) &&
+        isMember(side.faction, factions),
+    ) &&
+    value.sides[0].faction !== value.sides[1].faction &&
+    value.sides[0].control + value.sides[1].control === 100
+  );
+}
+
+function isPilotZoids(value: unknown): boolean {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      Array.isArray(value.damagedIds) &&
+      value.damagedIds.every(isKnownZoidId) &&
+      Array.isArray(value.reserveIds) &&
+      value.reserveIds.every(isKnownZoidId) &&
+      isKnownZoidId(value.signatureId))
+  );
+}
+
+function isKnownEventId(value: unknown): value is `event:${string}` {
+  if (typeof value !== "string" || !value.startsWith("event:")) {
+    return false;
+  }
+
+  try {
+    getEvent(value as `event:${string}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isKnownZoidId(value: unknown): value is ZoidId {
+  if (typeof value !== "string" || !value.startsWith("zoid:")) {
+    return false;
+  }
+
+  try {
+    getZoid(value as ZoidId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isBoundedValue(value: unknown): value is number {
+  return typeof value === "number" && value >= 0 && value <= 100;
+}
+
+function isNonNegativeInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function isMember<T extends string>(
+  value: unknown,
+  values: readonly T[],
+): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function isOptionalMember<T extends string>(
+  value: unknown,
+  values: readonly T[],
+): value is T | null {
+  return value === null || isMember(value, values);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -371,6 +371,8 @@ export interface FinalGameState {
 export type GameState =
   EventGameState | FinalGameState | PilotCreationGameState | WelcomeGameState;
 
+export type ActiveGameState = EventGameState | PilotCreationGameState;
+
 export function createBoundedValue(value: number): BoundedValue {
   if (!Number.isFinite(value) || value < 0 || value > 100) {
     throw new RangeError("The value must be a finite number from 0 to 100.");

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -20,6 +20,7 @@ import titles from "./locales/es/titles.json";
 import zoids from "./locales/es/zoids.json";
 
 export const defaultNamespace = "interface";
+export const languageStorageKey = "scars-of-steel:language";
 export const resources = {
   en: {
     achievements: achievementsEn,
@@ -42,6 +43,41 @@ export const resources = {
     zoids,
   },
 } as const;
+export const supportedLanguages = ["en", "es"] as const;
+export type Language = (typeof supportedLanguages)[number];
+
+export function loadLanguagePreference(): Language {
+  let storedLanguage: string | null = null;
+
+  try {
+    storedLanguage = window.localStorage.getItem(languageStorageKey);
+  } catch {
+    // Use the browser language when storage is unavailable.
+  }
+
+  const browserLanguages =
+    typeof navigator === "undefined"
+      ? []
+      : [...navigator.languages, navigator.language];
+
+  for (const candidate of [storedLanguage, ...browserLanguages]) {
+    const language = candidate?.toLowerCase().split("-")[0];
+
+    if (supportedLanguages.includes(language as Language)) {
+      return language as Language;
+    }
+  }
+
+  return "en";
+}
+
+export function saveLanguagePreference(language: Language) {
+  try {
+    window.localStorage.setItem(languageStorageKey, language);
+  } catch {
+    // Keep the selected language in memory when storage is unavailable.
+  }
+}
 
 export const i18n = createInstance();
 
@@ -52,7 +88,7 @@ void i18n.use(initReactI18next).init({
   interpolation: {
     escapeValue: false,
   },
-  lng: "en",
+  lng: loadLanguagePreference(),
   missingKeyHandler: import.meta.env.DEV
     ? (_languages, namespace, key) => {
         throw new Error(`Missing translation key "${namespace}:${key}".`);
@@ -60,7 +96,7 @@ void i18n.use(initReactI18next).init({
     : undefined,
   resources,
   saveMissing: import.meta.env.DEV,
-  supportedLngs: ["en", "es"],
+  supportedLngs: supportedLanguages,
 });
 
 export function translate(

--- a/src/index.css
+++ b/src/index.css
@@ -757,8 +757,47 @@
   background: var(--color-accent-soft);
 }
 
-.outcome-screen > .button {
-  justify-self: end;
+.outcome-screen__actions {
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-3);
+  justify-self: stretch;
+}
+
+.abandon-dialog__backdrop {
+  position: fixed;
+  z-index: 20;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  background: rgb(0 0 0 / 72%);
+}
+
+.abandon-dialog {
+  width: min(100%, 30rem);
+  padding: var(--space-6);
+  border: 1px solid var(--color-accent);
+  background: var(--color-panel-raised);
+  box-shadow: 0 1.5rem 5rem rgb(0 0 0 / 65%);
+}
+
+.abandon-dialog h2 {
+  margin-bottom: var(--space-3);
+  color: var(--color-heading);
+}
+
+.abandon-dialog p {
+  color: var(--color-text-muted);
+}
+
+.abandon-dialog > div {
+  display: flex;
+  justify-content: end;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
 }
 
 @keyframes target-impact {
@@ -1486,6 +1525,15 @@
     padding: clamp(var(--space-5), 5vw, var(--space-7));
   }
 
+  .welcome__panel--records {
+    grid-template-areas:
+      "badge"
+      "heading"
+      "facts"
+      "button"
+      "records";
+  }
+
   .app-shell .welcome__panel::after {
     top: 0;
     right: -10%;
@@ -1544,6 +1592,13 @@
   .welcome .button {
     width: 100%;
     min-width: 0;
+  }
+}
+
+@media (max-width: 64rem) {
+  .service-records {
+    width: 100%;
+    justify-self: stretch;
   }
 }
 
@@ -1966,7 +2021,7 @@
     font-size: 0.8rem;
   }
 
-  .outcome-screen > .button {
+  .outcome-screen__actions {
     width: 100%;
     justify-self: stretch;
   }
@@ -1986,6 +2041,49 @@
 }
 
 @media (max-width: 40rem) {
+  .service-records {
+    padding: var(--space-2);
+  }
+
+  .service-records__row {
+    width: 100%;
+    grid-template-columns: 1.75rem minmax(3.5rem, 1fr) 2.5rem 2.5rem 2rem 2rem;
+    gap: 0.2rem;
+    padding: var(--space-1);
+  }
+
+  .service-records__name,
+  .service-records__metric {
+    font-size: 0.62rem;
+  }
+
+  .service-records__zoid {
+    width: 2.5rem;
+  }
+
+  .service-records__rank {
+    width: 2.5rem;
+  }
+
+  .service-records__title {
+    width: 1.75rem;
+  }
+
+  .service-records__rank img,
+  .service-records__title img {
+    max-width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .service-records__rank small,
+  .service-records__zoid small {
+    font-size: 0.42rem;
+  }
+
+  .service-records__metric {
+    min-width: 2rem;
+  }
+
   .app-shell {
     background-position:
       35% 0,
@@ -2046,7 +2144,7 @@
     gap: var(--space-3);
   }
 
-  .outcome-screen > .button {
+  .outcome-screen__actions .button {
     min-height: 2.5rem;
     padding: var(--space-2) var(--space-4);
     font-size: 0.72rem;
@@ -2466,9 +2564,20 @@
     text-align: center;
   }
 
+  .welcome__brand {
+    width: 100%;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding-inline: var(--space-3);
+  }
+
   .welcome__heading h1 {
     max-width: 100%;
     font-size: clamp(2.75rem, 13.5vw, 4rem);
+  }
+
+  .welcome__logo {
+    width: clamp(4.5rem, 20vw, 6rem);
   }
 
   .welcome__heading p {

--- a/src/locales/en/interface.json
+++ b/src/locales/en/interface.json
@@ -135,6 +135,13 @@
     "title": "Cadet enlistment form"
   },
   "outcomeScreen": {
+    "abandon": "Abandon run",
+    "abandonDialog": {
+      "cancel": "Keep playing",
+      "confirm": "Abandon run",
+      "description": "Your current career progress will be deleted. This action cannot be undone.",
+      "title": "Abandon this run?"
+    },
     "achievementEarned": "Achievement earned",
     "badge": "Annual report",
     "battleInjured": "You were injured and withdrew from the remaining battles.",
@@ -202,6 +209,10 @@
       "en": "English",
       "es": "Spanish",
       "label": "Language"
+    },
+    "serviceRecords": {
+      "open": "Open final card for {{name}}",
+      "title": "Service records"
     },
     "start": "Begin your career",
     "title": "Scars of Steel"

--- a/src/locales/es/interface.json
+++ b/src/locales/es/interface.json
@@ -135,6 +135,13 @@
     "title": "Solicitud de alistamiento"
   },
   "outcomeScreen": {
+    "abandon": "Abandonar partida",
+    "abandonDialog": {
+      "cancel": "Seguir jugando",
+      "confirm": "Abandonar partida",
+      "description": "Se borrará el progreso de la carrera actual. Esta acción no se puede deshacer.",
+      "title": "¿Abandonar esta partida?"
+    },
     "achievementEarned": "Logro obtenido",
     "badge": "Informe anual",
     "battleInjured": "Terminaste con heridas y te retiraste de las batallas restantes.",
@@ -202,6 +209,10 @@
       "en": "Inglés",
       "es": "Español",
       "label": "Idioma"
+    },
+    "serviceRecords": {
+      "open": "Abrir tarjeta final de {{name}}",
+      "title": "Expedientes de servicio"
     },
     "start": "Inicia tu carrera",
     "title": "Cicatrices de Acero"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -289,6 +289,29 @@ p {
   transform: translateY(-2px);
 }
 
+.button--secondary {
+  border-color: var(--color-faction-secondary);
+  color: var(--color-heading);
+  background: color-mix(
+    in srgb,
+    var(--color-panel-raised) 78%,
+    var(--color-faction-secondary)
+  );
+  box-shadow:
+    0 0 0 0.25rem
+      color-mix(in srgb, var(--color-faction-secondary) 18%, transparent),
+    0 0.75rem 2rem
+      color-mix(in srgb, var(--color-faction-secondary) 15%, transparent);
+}
+
+.button--secondary:hover:not(:disabled) {
+  box-shadow:
+    0 0 0 0.35rem
+      color-mix(in srgb, var(--color-faction-secondary) 24%, transparent),
+    0 1rem 2.5rem
+      color-mix(in srgb, var(--color-faction-secondary) 20%, transparent);
+}
+
 .button:active:not(:disabled) {
   transform: translateY(0);
 }

--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -26,6 +26,15 @@
     inset 0 0 0 1px var(--color-border);
 }
 
+.welcome__panel--records {
+  grid-template-areas:
+    "badge facts"
+    "heading facts"
+    "button button"
+    "records records";
+  grid-template-rows: auto 1fr auto auto;
+}
+
 .app-shell[data-color-mode="light"] .welcome__panel {
   background:
     linear-gradient(112deg, rgb(248 250 255 / 96%) 0 64%, transparent 64%),
@@ -290,11 +299,13 @@
 
 .welcome__brand {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: clamp(var(--space-3), 2.5vw, var(--space-5));
 }
 
 .welcome__heading h1 {
+  min-width: 0;
   max-width: 10ch;
   color: var(--title-metal-light);
   background:
@@ -416,4 +427,237 @@
   grid-area: button;
   min-width: 15rem;
   justify-self: start;
+}
+
+.service-records {
+  z-index: 1;
+  width: min(100%, 33rem);
+  min-width: 0;
+  grid-area: records;
+  justify-self: start;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-top: 0.2rem solid var(--color-border-strong);
+  background: color-mix(in srgb, var(--color-panel) 90%, transparent);
+}
+
+.service-records h2 {
+  margin-bottom: var(--space-3);
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.service-records ul {
+  display: grid;
+  max-height: 12rem;
+  margin: 0;
+  overflow-y: auto;
+  gap: var(--space-2);
+  padding: 0;
+  list-style: none;
+}
+
+.service-records__row {
+  --record-accent: var(--color-accent);
+
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  min-height: 3.25rem;
+  grid-template-columns: 2.25rem minmax(6rem, 1fr) 4.5rem 5rem 2.5rem 2.5rem;
+  align-items: center;
+  justify-content: start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid
+    color-mix(in srgb, var(--record-accent) 34%, var(--color-border));
+  border-left: 0.25rem solid var(--record-accent);
+  color: inherit;
+  background: linear-gradient(
+    105deg,
+    color-mix(in srgb, var(--record-accent) 12%, var(--color-panel-raised)),
+    var(--color-panel-raised) 72%
+  );
+  box-shadow: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.service-records__row[data-faction="guylos"] {
+  --record-accent: #ff5d6c;
+}
+
+.service-records__row[data-faction="helic"] {
+  --record-accent: #5f8ee8;
+}
+
+.app-shell[data-color-mode="light"]
+  .service-records__row[data-faction="guylos"] {
+  --record-accent: #b2243a;
+}
+
+.app-shell[data-color-mode="light"]
+  .service-records__row[data-faction="helic"] {
+  --record-accent: #315aa8;
+}
+
+.service-records__row:hover,
+.service-records__row:focus-visible {
+  border-color: var(--record-accent);
+  box-shadow: 0 0 0 0.2rem
+    color-mix(in srgb, var(--record-accent) 22%, transparent);
+  outline: none;
+}
+
+.service-records__name {
+  overflow: hidden;
+  color: var(--color-heading);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.service-records__rank {
+  display: grid;
+  width: 4.5rem;
+  min-width: 0;
+  grid-template-rows: 2rem auto;
+  place-items: center;
+}
+
+.service-records__rank img {
+  width: auto;
+  max-width: 100%;
+  height: 1.75rem;
+}
+
+.service-records__zoid {
+  display: grid;
+  width: 5rem;
+  min-width: 0;
+  grid-template-rows: 2rem auto;
+  place-items: center;
+  overflow: hidden;
+  color: var(--record-accent);
+  font-size: 1.3rem;
+}
+
+.service-records__zoid img {
+  width: 3rem;
+  height: 2rem;
+  object-fit: contain;
+}
+
+.service-records__rank small,
+.service-records__zoid small {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.service-records__title {
+  display: grid;
+  width: 2.25rem;
+  height: 2.5rem;
+  place-items: center;
+}
+
+.service-records__title img {
+  width: 2rem;
+  height: 2rem;
+  object-fit: contain;
+}
+
+.service-records__metric {
+  display: inline-flex;
+  min-width: 3rem;
+  align-items: center;
+  justify-content: end;
+  gap: 0.2rem;
+  color: var(--record-accent);
+}
+
+.service-records__metric strong {
+  color: var(--color-heading);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (min-width: 64.01rem) {
+  :lang(es) .welcome__brand {
+    gap: var(--space-4);
+  }
+
+  :lang(es) .welcome__logo {
+    width: clamp(5rem, 9vw, 8rem);
+  }
+
+  :lang(es) .welcome__panel {
+    grid-template-columns: minmax(0, 1.6fr) minmax(17rem, 0.4fr);
+  }
+}
+
+@media (min-width: 64.01rem) and (max-width: 72rem) {
+  .welcome__heading {
+    container-type: inline-size;
+  }
+
+  .welcome__heading h1 {
+    font-size: clamp(3rem, 14cqi, 4.5rem);
+  }
+}
+
+@media (min-width: 64.01rem) {
+  .welcome__panel--records {
+    grid-template-areas:
+      "badge facts"
+      "heading facts"
+      "button records";
+    grid-template-columns: minmax(0, 1fr) minmax(28rem, 0.7fr);
+    grid-template-rows: auto 1fr auto;
+  }
+
+  :lang(es) .welcome__panel--records {
+    grid-template-columns: minmax(0, 1fr) minmax(24rem, 0.55fr);
+  }
+
+  .welcome__panel--records .welcome__facts {
+    width: calc(100% - var(--space-7));
+    justify-self: end;
+  }
+
+  .welcome__panel--records .service-records {
+    width: calc(120% + var(--space-5));
+    align-self: end;
+    justify-self: end;
+  }
+
+  .welcome__panel--records > .button {
+    align-self: start;
+  }
+
+  .welcome__panel--records .service-records__row {
+    grid-template-columns: 2rem minmax(5rem, 1fr) 4rem 4.5rem 2.25rem 2.25rem;
+    gap: 0.35rem;
+  }
+
+  .welcome__panel--records .service-records__rank {
+    width: 4rem;
+  }
+
+  .welcome__panel--records .service-records__title {
+    width: 2rem;
+  }
+
+  .welcome__panel--records .service-records__zoid {
+    width: 4.5rem;
+  }
+
+  .welcome__panel--records .service-records__metric {
+    min-width: 2.25rem;
+  }
 }

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -4,19 +4,55 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { App } from "../app/App";
+import { colorModeStorageKey } from "../app/colorModeStorage";
 import { PilotCreationScreen } from "../app/PilotCreationScreen";
 import { WelcomeScreen } from "../app/WelcomeScreen";
+import type { CompletedGame } from "../app/gameStorage";
+import { createCareerHistory } from "../domain/career";
+import { createInitialPilot } from "../domain/pilot";
+import { createBoundedValue, type PilotDraft } from "../domain/types";
 import { i18n } from "../i18n";
-import type { PilotDraft } from "../domain/types";
+
+const completedPilot = createInitialPilot({
+  aspiration: "commander",
+  faction: "helic",
+  id: "pilot:lena",
+  name: "Lena Steel",
+});
+const completedGame = {
+  state: {
+    endReason: "no-eligible-events",
+    history: createCareerHistory(),
+    nicknameId: "nickname:guardian",
+    pilot: {
+      ...completedPilot,
+      career: {
+        ...completedPilot.career,
+        fame: createBoundedValue(62),
+        militaryRank: "captain",
+      },
+      potential: createBoundedValue(74),
+      zoids: {
+        damagedIds: [],
+        reserveIds: [],
+        signatureId: "zoid:command-wolf",
+      },
+    },
+    screen: "final",
+    titleId: "title:false-promise",
+  },
+} as const satisfies CompletedGame;
 
 afterEach(() => {
   cleanup();
   document.documentElement.lang = "en";
+  window.localStorage.clear();
   void i18n.changeLanguage("en");
 });
 
@@ -62,7 +98,9 @@ describe("welcome screen", () => {
 
     render(
       <WelcomeScreen
+        completedGames={[]}
         onReducedMotionChange={() => undefined}
+        onSelectGame={() => undefined}
         onStart={() => undefined}
         reducedMotion={false}
       />,
@@ -90,12 +128,62 @@ describe("welcome screen", () => {
     ).toBeInTheDocument();
   });
 
+  test("shows compact service records without visible Zoid names", () => {
+    const onSelectGame = vi.fn();
+    render(
+      <WelcomeScreen
+        completedGames={[completedGame]}
+        onReducedMotionChange={() => undefined}
+        onSelectGame={onSelectGame}
+        onStart={() => undefined}
+        reducedMotion={false}
+      />,
+    );
+
+    const record = screen.getByText("Lena Steel").closest("li");
+    expect(record).not.toBeNull();
+    expect(within(record!).getByText("Captain")).toBeInTheDocument();
+    expect(
+      within(record!).getByLabelText("Captain").querySelector("img"),
+    ).toHaveAttribute("src", "/images/ranks/captain.png");
+    expect(within(record!).getByText("Command Wolf")).toBeInTheDocument();
+    const zoid = within(record!).getByLabelText("Zoid: Command Wolf");
+    expect(zoid).toHaveClass("service-records__zoid");
+    expect(zoid.querySelector("img")).toHaveAttribute(
+      "src",
+      "/images/zoids/command_wolf.png",
+    );
+    expect(
+      within(record!).getByLabelText("False promise").querySelector("img"),
+    ).toHaveAttribute("src", "/images/icons/titles/false-promise.png");
+    expect(
+      within(record!).getByLabelText("Potential: 74 of 100"),
+    ).toHaveTextContent("⚡74");
+    expect(within(record!).getByLabelText("Fame: 62 of 100")).toHaveTextContent(
+      "★62",
+    );
+    const row = within(record!).getByRole("button", {
+      name: "Open final card for Lena Steel",
+    });
+    expect(row).toHaveAttribute("data-faction", "helic");
+    fireEvent.click(row);
+    expect(onSelectGame).toHaveBeenCalledWith(completedGame);
+    expect(
+      screen
+        .getByRole("button", { name: "Begin your career" })
+        .compareDocumentPosition(screen.getByText("Service records")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   test("starts the flow only once", () => {
     const onStart = vi.fn();
 
     render(
       <WelcomeScreen
+        completedGames={[]}
         onReducedMotionChange={() => undefined}
+        onSelectGame={() => undefined}
         onStart={onStart}
         reducedMotion={false}
       />,
@@ -340,7 +428,7 @@ describe("pilot creation", () => {
   });
 
   test("resolves a safe initial decision once and opens its outcome", async () => {
-    render(<App />);
+    const firstRender = render(<App />);
     await startPilotCreation();
     fireEvent.change(screen.getByRole("textbox", { name: "Recruit name" }), {
       target: { value: "Lena" },
@@ -366,17 +454,104 @@ describe("pilot creation", () => {
     );
     expect(document.querySelector(".outcome-screen h1")).toHaveFocus();
     expect(screen.getByLabelText("Career status")).toBeInTheDocument();
+
+    const outcome = screen.getByRole("heading", { level: 1 }).textContent;
+    firstRender.unmount();
+    render(<App />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      outcome!,
+    );
+    expect(
+      screen.getByRole("button", { name: "Continue career" }),
+    ).toBeInTheDocument();
   });
 
-  test("starts again at the welcome screen after remounting", async () => {
+  test("restores the exact resolved chance roll", async () => {
+    const firstRender = render(<App />);
+    await startPilotCreation();
+    fireEvent.change(screen.getByRole("textbox", { name: "Recruit name" }), {
+      target: { value: "Lena" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Helic Republic" }));
+    fireEvent.click(screen.getByRole("radio", { name: "War hero" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit enlistment" }));
+
+    await screen.findByText("Choose your response");
+    const chanceDecision = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".decision-option"),
+    ).find((option) => option.ariaLabel?.includes(". With risk."));
+    fireEvent.click(chanceDecision!);
+
+    const firstStatus = await screen.findByRole("status");
+    const firstTarget = await screen.findByRole("img", {
+      name: /Resolution target/u,
+    });
+    const result = firstStatus.dataset.result;
+    const style = firstTarget.getAttribute("style");
+    firstRender.unmount();
+    render(<App />);
+
+    expect(await screen.findByRole("status")).toHaveAttribute(
+      "data-result",
+      result,
+    );
+    expect(
+      await screen.findByRole("img", { name: /Resolution target/u }),
+    ).toHaveAttribute("style", style);
+  });
+
+  test("restores pilot creation after remounting", async () => {
     const firstRender = render(<App />);
     expect(await startPilotCreation()).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox", { name: "Recruit name" }), {
+      target: { value: "Lena" },
+    });
 
     firstRender.unmount();
     render(<App />);
 
     expect(
-      screen.getByRole("heading", { name: "Scars of Steel" }),
+      screen.getByRole("heading", { name: "Cadet enlistment form" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Recruit name" })).toHaveValue(
+      "Lena",
+    );
+  });
+
+  test("abandons an active run after confirmation", async () => {
+    const firstRender = render(<App />);
+    await startPilotCreation();
+    fireEvent.change(screen.getByRole("textbox", { name: "Recruit name" }), {
+      target: { value: "Lena" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Helic Republic" }));
+    fireEvent.click(screen.getByRole("radio", { name: "War hero" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit enlistment" }));
+
+    await screen.findByText("Choose your response");
+    const safeDecision = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".decision-option"),
+    ).find((option) => option.ariaLabel?.includes(". Safe."));
+    fireEvent.click(safeDecision!);
+    fireEvent.click(await screen.findByRole("button", { name: "Abandon run" }));
+    fireEvent.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Abandon run",
+      }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Begin your career" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Service records" }),
+    ).toBeNull();
+
+    firstRender.unmount();
+    render(<App />);
+    expect(
+      screen.getByRole("button", { name: "Begin your career" }),
     ).toBeInTheDocument();
   });
 
@@ -411,10 +586,29 @@ describe("pilot creation", () => {
       screen.getByRole("button", { name: "Download PNG" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "New run" }));
+    expect(screen.getByRole("button", { name: "New run" })).toBeInTheDocument();
+    cleanup();
+    render(<App />);
+
     expect(
       await screen.findByRole("button", { name: "Begin your career" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Service records" }),
+    ).toBeInTheDocument();
+    const record = screen.getByText("Lena").closest("li");
+    expect(record).not.toBeNull();
+    expect(within(record!).getByLabelText("Cadet")).toBeInTheDocument();
+    expect(within(record!).getByLabelText(/Potential:/u)).toBeInTheDocument();
+    expect(within(record!).getByLabelText(/Fame:/u)).toBeInTheDocument();
+    fireEvent.click(within(record!).getByRole("button"));
+    expect(
+      await screen.findByRole("heading", { name: "False promise" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("main").closest(".app-shell")).toHaveAttribute(
+      "data-faction",
+      "helic",
+    );
   });
 });
 
@@ -436,6 +630,20 @@ test("changes between dark and light modes", () => {
     .closest(".app-shell");
   expect(colorModeSwitch).toBeChecked();
   expect(app).toHaveAttribute("data-color-mode", "light");
+  expect(window.localStorage.getItem(colorModeStorageKey)).toBe("light");
+});
+
+test("loads the saved color mode", () => {
+  window.localStorage.setItem(colorModeStorageKey, "light");
+
+  render(<App />);
+
+  expect(screen.getByRole("switch", { name: "Light mode" })).toBeChecked();
+  expect(
+    screen
+      .getByRole("heading", { name: "Scars of Steel" })
+      .closest(".app-shell"),
+  ).toHaveAttribute("data-color-mode", "light");
 });
 
 test("turns animations on and off", () => {

--- a/src/tests/DecisionScreen.test.tsx
+++ b/src/tests/DecisionScreen.test.tsx
@@ -219,6 +219,7 @@ describe("decision resolution", () => {
     view.rerender(
       <DecisionScreen
         event={event}
+        onAbandon={() => undefined}
         onCloseYear={() => undefined}
         onDecision={() => undefined}
         onReducedMotionChange={() => undefined}
@@ -363,6 +364,39 @@ describe("decision resolution", () => {
     expect(screen.getByText("Born in the workshop")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Continue career" }));
     expect(onCloseYear).toHaveBeenCalledOnce();
+  });
+
+  test("confirms before abandoning the run", () => {
+    const onAbandon = vi.fn();
+    renderScreen(
+      { ...createAnimatingState(0.2), phase: "outcome" },
+      {
+        onAbandon,
+      },
+    );
+
+    const abandonButton = screen.getByRole("button", { name: "Abandon run" });
+    expect(abandonButton).toHaveClass("button--secondary");
+    fireEvent.click(abandonButton);
+
+    const dialog = screen.getByRole("alertdialog", {
+      name: "Abandon this run?",
+    });
+    const cancel = within(dialog).getByRole("button", {
+      name: "Keep playing",
+    });
+    expect(cancel).toHaveFocus();
+    fireEvent.click(cancel);
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(onAbandon).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Abandon run" }));
+    fireEvent.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Abandon run",
+      }),
+    );
+    expect(onAbandon).toHaveBeenCalledOnce();
   });
 
   test("shows effective stat changes as compact outcome tags", () => {
@@ -550,6 +584,7 @@ describe("decision resolution", () => {
     view.rerender(
       <DecisionScreen
         event={event}
+        onAbandon={() => undefined}
         onCloseYear={() => undefined}
         onDecision={() => undefined}
         onReducedMotionChange={() => undefined}
@@ -567,6 +602,7 @@ describe("decision resolution", () => {
 
 interface RenderOverrides {
   event?: DecisionEvent;
+  onAbandon?: () => void;
   onCloseYear?: () => void;
   onDecision?: (decision: Decision) => void;
   onReducedMotionChange?: (reducedMotion: boolean) => void;
@@ -578,6 +614,7 @@ function renderScreen(state: EventGameState, overrides: RenderOverrides = {}) {
   return render(
     <DecisionScreen
       event={overrides.event ?? event}
+      onAbandon={overrides.onAbandon ?? (() => undefined)}
       onCloseYear={overrides.onCloseYear ?? (() => undefined)}
       onDecision={overrides.onDecision ?? (() => undefined)}
       onReducedMotionChange={

--- a/src/tests/colorModeStorage.test.ts
+++ b/src/tests/colorModeStorage.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  colorModeStorageKey,
+  loadColorModePreference,
+  saveColorModePreference,
+} from "../app/colorModeStorage";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("color mode preference", () => {
+  test("loads the saved color mode", () => {
+    window.localStorage.setItem(colorModeStorageKey, "light");
+
+    expect(loadColorModePreference()).toBe("light");
+  });
+
+  test("uses dark mode for an invalid stored value", () => {
+    window.localStorage.setItem(colorModeStorageKey, "invalid");
+
+    expect(loadColorModePreference()).toBe("dark");
+  });
+
+  test("saves the selected color mode", () => {
+    saveColorModePreference("light");
+
+    expect(window.localStorage.getItem(colorModeStorageKey)).toBe("light");
+  });
+
+  test("continues when browser storage fails", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable.");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is full.");
+    });
+
+    expect(loadColorModePreference()).toBe("dark");
+    expect(() => saveColorModePreference("light")).not.toThrow();
+  });
+});

--- a/src/tests/gameStorage.test.ts
+++ b/src/tests/gameStorage.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createEmptyGameData,
+  loadGameData,
+  saveGameData,
+  type StoredGameData,
+} from "../app/gameStorage";
+
+const gameStorageKey = "scars-of-steel:game-data";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("game storage", () => {
+  test("loads versioned game data", () => {
+    const data = {
+      activeGame: null,
+      completedGames: [],
+      version: 2,
+    } as const satisfies StoredGameData;
+
+    saveGameData(data);
+
+    expect(loadGameData()).toEqual(data);
+  });
+
+  test.each([
+    "not-json",
+    JSON.stringify({ activeGame: null, completedGames: [], version: 1 }),
+    JSON.stringify({ activeGame: { screen: "event" }, version: 2 }),
+  ])("ignores damaged or incompatible data", (storedValue) => {
+    window.localStorage.setItem(gameStorageKey, storedValue);
+
+    expect(loadGameData()).toEqual(createEmptyGameData());
+  });
+
+  test("continues when browser storage fails", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable.");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is full.");
+    });
+
+    expect(loadGameData()).toEqual(createEmptyGameData());
+    expect(() => saveGameData(createEmptyGameData())).not.toThrow();
+  });
+});

--- a/src/tests/i18n.test.ts
+++ b/src/tests/i18n.test.ts
@@ -1,9 +1,56 @@
-import { expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { achievementDescriptionKeys } from "../domain/achievements";
-import { nicknameIds, getNicknameKey } from "../domain/nicknames";
+import { getNicknameKey, nicknameIds } from "../domain/nicknames";
 import { titleCatalog } from "../domain/titles";
-import { i18n } from "../i18n";
+import {
+  i18n,
+  languageStorageKey,
+  loadLanguagePreference,
+  saveLanguagePreference,
+} from "../i18n";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("language preference", () => {
+  test("uses the saved language before the browser language", () => {
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["en-US"]);
+    window.localStorage.setItem(languageStorageKey, "es");
+
+    expect(loadLanguagePreference()).toBe("es");
+  });
+
+  test("uses a supported regional browser language", () => {
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue([
+      "es-MX",
+      "en-US",
+    ]);
+
+    expect(loadLanguagePreference()).toBe("es");
+  });
+
+  test("saves the selected language", () => {
+    saveLanguagePreference("es");
+
+    expect(window.localStorage.getItem(languageStorageKey)).toBe("es");
+  });
+
+  test("continues when browser storage fails", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable.");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is full.");
+    });
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["es-MX"]);
+
+    expect(loadLanguagePreference()).toBe("es");
+    expect(() => saveLanguagePreference("es")).not.toThrow();
+  });
+});
 
 test("interpolates pilot values", () => {
   expect(


### PR DESCRIPTION
## Summary

- Persist the active career and completed service records in browser storage.
- Restore active careers without storing random seed or random state.
- Add a responsive Service Records panel that opens completed career cards.
- Add faction styling and career details to each service record.
- Add a confirmed abandon action to decision outcomes.
- Detect and persist the selected language.
- Persist the selected light or dark theme.

## Test plan

- `npm run lint`
- `npm test -- --run`
- `npm run build`

Closes #11