### PR TITLE
Implement explicit game flow reducer

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 
 import { getEligibleEventIds, selectEvent } from "../domain/eventPools";
 import { getEvent } from "../domain/events";
@@ -11,11 +11,7 @@ import {
 import { selectNickname } from "../domain/nicknames";
 import { createInitialPilot } from "../domain/pilot";
 import { createSecureRandomGenerator } from "../domain/random";
-import type {
-  Decision,
-  GameState,
-  PilotCreationGameState,
-} from "../domain/types";
+import type { Decision, PilotCreationGameState } from "../domain/types";
 import { selectTitle } from "../domain/titles";
 import { resolveYear } from "../domain/year";
 import { AppControls } from "./AppControls";
@@ -25,12 +21,8 @@ import {
 } from "./colorModeStorage";
 import { DecisionScreen } from "./DecisionScreen";
 import { FinalScreen } from "./FinalScreen";
-import {
-  type CompletedGame,
-  createCompletedGame,
-  loadGameData,
-  saveGameData,
-} from "./gameStorage";
+import { type CompletedGame, loadGameData, saveGameData } from "./gameStorage";
+import { type AppState, GameActionType, gameReducer } from "./gameReducer";
 import {
   PilotCreationScreen,
   type PilotConfiguration,
@@ -39,22 +31,13 @@ import { ScreenTransition } from "./ScreenTransition";
 import { WelcomeScreen } from "./WelcomeScreen";
 
 export function App() {
-  const [appState, setAppState] = useState<{
-    completedGames: readonly CompletedGame[];
-    gameState: GameState;
-  }>(() => {
-    const storedData = loadGameData();
-
-    return {
-      completedGames: storedData.completedGames,
-      gameState: storedData.activeGame ?? ({ screen: "welcome" } as const),
-    };
-  });
+  const [appState, dispatch] = useReducer(
+    gameReducer,
+    undefined,
+    createInitialAppState,
+  );
   const [colorMode, setColorMode] = useState(loadColorModePreference);
   const [reducedMotion, setReducedMotion] = useState(false);
-  const hasResolvedDecisionRef = useRef(false);
-  const hasClosedYearRef = useRef(false);
-  const hasCreatedPilotRef = useRef(false);
   const randomRef = useRef(createSecureRandomGenerator());
   const { gameState } = appState;
 
@@ -74,48 +57,23 @@ export function App() {
     saveColorModePreference(colorMode);
   }, [colorMode]);
 
-  function updateGameState(
-    update: GameState | ((currentState: GameState) => GameState),
-  ) {
-    setAppState((currentState) => ({
-      ...currentState,
-      gameState:
-        typeof update === "function" ? update(currentState.gameState) : update,
-    }));
-  }
-
   function openCompletedGame(game: CompletedGame) {
-    updateGameState(game.state);
+    dispatch({ game, type: GameActionType.OpenCompletedGame });
   }
 
   function startGame() {
-    hasClosedYearRef.current = false;
-    hasResolvedDecisionRef.current = false;
-    hasCreatedPilotRef.current = false;
-    updateGameState((currentState) =>
-      currentState.screen === "welcome"
-        ? {
-            draft: { aspiration: null, faction: null, name: "" },
-            screen: "pilot-creation",
-          }
-        : currentState,
-    );
+    dispatch({ type: GameActionType.StartGame });
   }
 
   function changePilotDraft(draft: PilotCreationGameState["draft"]) {
-    updateGameState((currentState) =>
-      currentState.screen === "pilot-creation"
-        ? { ...currentState, draft }
-        : currentState,
-    );
+    dispatch({ draft, type: GameActionType.ChangePilotDraft });
   }
 
   function confirmPilot(configuration: PilotConfiguration) {
-    if (hasCreatedPilotRef.current) {
+    if (gameState.screen !== "pilot-creation") {
       return;
     }
 
-    hasCreatedPilotRef.current = true;
     const pilot = createInitialPilot({
       ...configuration,
       id: `pilot:${crypto.randomUUID()}`,
@@ -126,21 +84,16 @@ export function App() {
       randomRef.current,
     );
 
-    updateGameState({
+    dispatch({
       eventId: event.id,
       history,
-      phase: "choosing",
       pilot,
-      screen: "event",
+      type: GameActionType.ConfirmPilot,
     });
   }
 
   function chooseDecision(decision: Decision) {
-    if (
-      hasResolvedDecisionRef.current ||
-      gameState.screen !== "event" ||
-      gameState.phase !== "choosing"
-    ) {
+    if (gameState.screen !== "event" || gameState.phase !== "choosing") {
       return;
     }
 
@@ -152,47 +105,18 @@ export function App() {
       randomRef.current,
     );
 
-    hasResolvedDecisionRef.current = true;
-    hasClosedYearRef.current = false;
-    updateGameState({
-      eventId: gameState.eventId,
-      history: gameState.history,
-      ...(result.resolution.kind === "chance"
-        ? {
-            phase: "animating" as const,
-            result: { ...result, resolution: result.resolution },
-          }
-        : { phase: "outcome" as const, result }),
-      screen: "event",
-      pilot: result.pilotAfter,
-    });
+    dispatch({ result, type: GameActionType.ChooseDecision });
   }
 
   function revealOutcome() {
-    updateGameState((currentState) =>
-      currentState.screen === "event" && currentState.phase === "animating"
-        ? {
-            eventId: currentState.eventId,
-            history: currentState.history,
-            phase: "outcome",
-            pilot: currentState.pilot,
-            result: currentState.result,
-            screen: "event",
-          }
-        : currentState,
-    );
+    dispatch({ type: GameActionType.RevealOutcome });
   }
 
   function closeYear() {
-    if (
-      hasClosedYearRef.current ||
-      gameState.screen !== "event" ||
-      gameState.phase !== "outcome"
-    ) {
+    if (gameState.screen !== "event" || gameState.phase !== "outcome") {
       return;
     }
 
-    hasClosedYearRef.current = true;
     const history = recordResolvedYear(
       gameState.history,
       gameState.eventId,
@@ -219,36 +143,22 @@ export function App() {
         titleId: selectTitle(pilot, history, endReason),
       } as const;
 
-      setAppState((currentState) => ({
-        completedGames: [
-          createCompletedGame(finalState),
-          ...currentState.completedGames.filter(
-            ({ state }) => state.pilot.id !== pilot.id,
-          ),
-        ],
-        gameState: finalState,
-      }));
+      dispatch({ state: finalState, type: GameActionType.CompleteCareer });
       return;
     }
 
-    hasClosedYearRef.current = false;
-    hasResolvedDecisionRef.current = false;
     const event = selectEvent(eligibleEventIds, randomRef.current);
 
-    updateGameState({
+    dispatch({
       eventId: event.id,
       history,
-      phase: "choosing",
       pilot,
-      screen: "event",
+      type: GameActionType.AdvanceYear,
     });
   }
 
   function restartGame() {
-    hasClosedYearRef.current = false;
-    hasCreatedPilotRef.current = false;
-    hasResolvedDecisionRef.current = false;
-    updateGameState({ screen: "welcome" });
+    dispatch({ type: GameActionType.RestartGame });
   }
 
   const faction =
@@ -308,6 +218,15 @@ export function App() {
       </ScreenTransition>
     </div>
   );
+}
+
+function createInitialAppState(): AppState {
+  const storedData = loadGameData();
+
+  return {
+    completedGames: storedData.completedGames,
+    gameState: storedData.activeGame ?? { screen: "welcome" },
+  };
 }
 
 function BackgroundDamage() {

--- a/src/app/gameReducer.ts
+++ b/src/app/gameReducer.ts
@@ -1,0 +1,189 @@
+import type {
+  CareerHistory,
+  EventId,
+  FinalGameState,
+  GameState,
+  Pilot,
+  PilotDraft,
+  ResolvedYear,
+} from "../domain/types";
+import type { CompletedGame } from "./gameStorage";
+
+export interface AppState {
+  completedGames: readonly CompletedGame[];
+  gameState: GameState;
+}
+
+export const GameActionType = {
+  AdvanceYear: "advance-year",
+  ChangePilotDraft: "change-pilot-draft",
+  ChooseDecision: "choose-decision",
+  CompleteCareer: "complete-career",
+  ConfirmPilot: "confirm-pilot",
+  OpenCompletedGame: "open-completed-game",
+  RestartGame: "restart-game",
+  RevealOutcome: "reveal-outcome",
+  StartGame: "start-game",
+} as const;
+
+interface AdvanceYearAction {
+  eventId: EventId;
+  history: CareerHistory;
+  pilot: Pilot;
+  type: typeof GameActionType.AdvanceYear;
+}
+
+interface ChangePilotDraftAction {
+  draft: PilotDraft;
+  type: typeof GameActionType.ChangePilotDraft;
+}
+
+interface ChooseDecisionAction {
+  result: ResolvedYear;
+  type: typeof GameActionType.ChooseDecision;
+}
+
+interface CompleteCareerAction {
+  state: FinalGameState;
+  type: typeof GameActionType.CompleteCareer;
+}
+
+interface ConfirmPilotAction {
+  eventId: EventId;
+  history: CareerHistory;
+  pilot: Pilot;
+  type: typeof GameActionType.ConfirmPilot;
+}
+
+interface OpenCompletedGameAction {
+  game: CompletedGame;
+  type: typeof GameActionType.OpenCompletedGame;
+}
+
+interface RestartGameAction {
+  type: typeof GameActionType.RestartGame;
+}
+
+interface RevealOutcomeAction {
+  type: typeof GameActionType.RevealOutcome;
+}
+
+interface StartGameAction {
+  type: typeof GameActionType.StartGame;
+}
+
+export type GameAction =
+  | AdvanceYearAction
+  | ChangePilotDraftAction
+  | ChooseDecisionAction
+  | CompleteCareerAction
+  | ConfirmPilotAction
+  | OpenCompletedGameAction
+  | RestartGameAction
+  | RevealOutcomeAction
+  | StartGameAction;
+
+export function gameReducer(state: AppState, action: GameAction): AppState {
+  switch (action.type) {
+    case GameActionType.AdvanceYear:
+      return state.gameState.screen === "event" &&
+        state.gameState.phase === "outcome" &&
+        state.gameState.pilot.id === action.pilot.id
+        ? {
+            ...state,
+            gameState: {
+              eventId: action.eventId,
+              history: action.history,
+              phase: "choosing",
+              pilot: action.pilot,
+              screen: "event",
+            },
+          }
+        : state;
+    case GameActionType.ChangePilotDraft:
+      return state.gameState.screen === "pilot-creation"
+        ? {
+            ...state,
+            gameState: { ...state.gameState, draft: action.draft },
+          }
+        : state;
+    case GameActionType.ChooseDecision:
+      return state.gameState.screen === "event" &&
+        state.gameState.phase === "choosing" &&
+        state.gameState.pilot.id === action.result.pilotBefore.id &&
+        state.gameState.pilot.id === action.result.pilotAfter.id
+        ? {
+            ...state,
+            gameState: {
+              eventId: state.gameState.eventId,
+              history: state.gameState.history,
+              ...(action.result.resolution.kind === "chance"
+                ? {
+                    phase: "animating" as const,
+                    result: {
+                      ...action.result,
+                      resolution: action.result.resolution,
+                    },
+                  }
+                : { phase: "outcome" as const, result: action.result }),
+              pilot: action.result.pilotAfter,
+              screen: "event",
+            },
+          }
+        : state;
+    case GameActionType.CompleteCareer:
+      return state.gameState.screen === "event" &&
+        state.gameState.phase === "outcome" &&
+        state.gameState.pilot.id === action.state.pilot.id
+        ? {
+            completedGames: [
+              { state: action.state },
+              ...state.completedGames.filter(
+                ({ state: completedState }) =>
+                  completedState.pilot.id !== action.state.pilot.id,
+              ),
+            ],
+            gameState: action.state,
+          }
+        : state;
+    case GameActionType.ConfirmPilot:
+      return state.gameState.screen === "pilot-creation"
+        ? {
+            ...state,
+            gameState: {
+              eventId: action.eventId,
+              history: action.history,
+              phase: "choosing",
+              pilot: action.pilot,
+              screen: "event",
+            },
+          }
+        : state;
+    case GameActionType.OpenCompletedGame:
+      return state.gameState.screen === "welcome"
+        ? { ...state, gameState: action.game.state }
+        : state;
+    case GameActionType.RestartGame:
+      return state.gameState.screen === "welcome"
+        ? state
+        : { ...state, gameState: { screen: "welcome" } };
+    case GameActionType.RevealOutcome:
+      return state.gameState.screen === "event" &&
+        state.gameState.phase === "animating"
+        ? {
+            ...state,
+            gameState: { ...state.gameState, phase: "outcome" },
+          }
+        : state;
+    case GameActionType.StartGame:
+      return state.gameState.screen === "welcome"
+        ? {
+            ...state,
+            gameState: {
+              draft: { aspiration: null, faction: null, name: "" },
+              screen: "pilot-creation",
+            },
+          }
+        : state;
+  }
+}

--- a/src/tests/gameReducer.test.ts
+++ b/src/tests/gameReducer.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  type AppState,
+  type GameAction,
+  GameActionType,
+  gameReducer,
+} from "../app/gameReducer";
+import { createCompletedGame } from "../app/gameStorage";
+import { advanceCareerYear, createCareerHistory } from "../domain/career";
+import { eventCatalog } from "../domain/events";
+import { createInitialPilot } from "../domain/pilot";
+import { createSeededRandomGenerator } from "../domain/random";
+import type { FinalGameState, OutcomeEventGameState } from "../domain/types";
+import { resolveYear } from "../domain/year";
+
+const history = createCareerHistory();
+const pilot = createInitialPilot({
+  aspiration: "war-hero",
+  faction: "helic",
+  id: "pilot:reducer",
+  name: "Lena",
+});
+const welcomeState = {
+  completedGames: [],
+  gameState: { screen: "welcome" },
+} as const satisfies AppState;
+
+function createChoosingState(): AppState {
+  return {
+    completedGames: [],
+    gameState: {
+      eventId: eventCatalog.firstExercises.id,
+      history,
+      phase: "choosing",
+      pilot,
+      screen: "event",
+    },
+  };
+}
+
+function createOutcomeState(): AppState & {
+  gameState: OutcomeEventGameState;
+} {
+  const result = resolveYear(
+    eventCatalog.firstExercises.decisions[0],
+    eventCatalog.firstExercises,
+    pilot,
+    createSeededRandomGenerator(1),
+  );
+
+  return {
+    completedGames: [],
+    gameState: {
+      eventId: eventCatalog.firstExercises.id,
+      history,
+      phase: "outcome",
+      pilot: result.pilotAfter,
+      result,
+      screen: "event",
+    },
+  };
+}
+
+function createFinalState(
+  outcomeState: ReturnType<typeof createOutcomeState>,
+): FinalGameState {
+  return {
+    endReason: "no-eligible-events",
+    history: outcomeState.gameState.history,
+    nicknameId: "nickname:guardian",
+    pilot: advanceCareerYear(outcomeState.gameState.pilot),
+    screen: "final",
+    titleId: "title:false-promise",
+  };
+}
+
+describe("game reducer", () => {
+  test("starts the game and changes the pilot draft", () => {
+    const started = gameReducer(welcomeState, {
+      type: GameActionType.StartGame,
+    });
+    const draft = {
+      aspiration: "war-hero",
+      faction: "helic",
+      name: "Lena",
+    } as const;
+    const changed = gameReducer(started, {
+      draft,
+      type: GameActionType.ChangePilotDraft,
+    });
+
+    expect(started.gameState).toEqual({
+      draft: { aspiration: null, faction: null, name: "" },
+      screen: "pilot-creation",
+    });
+    expect(changed.gameState).toEqual({
+      draft,
+      screen: "pilot-creation",
+    });
+  });
+
+  test("confirms a pilot only once", () => {
+    const started = gameReducer(welcomeState, {
+      type: GameActionType.StartGame,
+    });
+    const action = {
+      eventId: eventCatalog.firstExercises.id,
+      history,
+      pilot,
+      type: GameActionType.ConfirmPilot,
+    } as const satisfies GameAction;
+    const confirmed = gameReducer(started, action);
+
+    expect(confirmed.gameState).toMatchObject({
+      eventId: eventCatalog.firstExercises.id,
+      phase: "choosing",
+      pilot,
+      screen: "event",
+    });
+    expect(gameReducer(confirmed, action)).toBe(confirmed);
+  });
+
+  test("resolves a safe decision only once", () => {
+    const state = createChoosingState();
+    const action = {
+      result: resolveYear(
+        eventCatalog.firstExercises.decisions[0],
+        eventCatalog.firstExercises,
+        pilot,
+        createSeededRandomGenerator(1),
+      ),
+      type: GameActionType.ChooseDecision,
+    } as const satisfies GameAction;
+    const resolved = gameReducer(state, action);
+
+    expect(resolved.gameState).toMatchObject({
+      phase: "outcome",
+      screen: "event",
+    });
+    expect(gameReducer(resolved, action)).toBe(resolved);
+  });
+
+  test("animates a chance decision before revealing its outcome", () => {
+    const state = createChoosingState();
+    const resolved = gameReducer(state, {
+      result: resolveYear(
+        eventCatalog.firstExercises.decisions[1],
+        eventCatalog.firstExercises,
+        pilot,
+        createSeededRandomGenerator(1),
+      ),
+      type: GameActionType.ChooseDecision,
+    });
+    const revealed = gameReducer(resolved, {
+      type: GameActionType.RevealOutcome,
+    });
+
+    expect(resolved.gameState).toMatchObject({
+      phase: "animating",
+      screen: "event",
+    });
+    expect(revealed.gameState).toMatchObject({
+      phase: "outcome",
+      screen: "event",
+    });
+    expect(gameReducer(revealed, { type: GameActionType.RevealOutcome })).toBe(
+      revealed,
+    );
+  });
+
+  test("advances from an outcome to the next event", () => {
+    const state = createOutcomeState();
+    const nextPilot = advanceCareerYear(state.gameState.pilot);
+    const advanced = gameReducer(state, {
+      eventId: eventCatalog.strayZoid.id,
+      history: state.gameState.history,
+      pilot: nextPilot,
+      type: GameActionType.AdvanceYear,
+    });
+
+    expect(advanced.gameState).toEqual({
+      eventId: eventCatalog.strayZoid.id,
+      history: state.gameState.history,
+      phase: "choosing",
+      pilot: nextPilot,
+      screen: "event",
+    });
+  });
+
+  test("completes a career atomically and replaces its previous record", () => {
+    const state = createOutcomeState();
+    const finalState = createFinalState(state);
+    const otherFinalState = {
+      ...finalState,
+      pilot: { ...finalState.pilot, id: "pilot:other" },
+    } as const satisfies FinalGameState;
+    const stateWithRecords = {
+      ...state,
+      completedGames: [
+        createCompletedGame({ ...finalState, titleId: "title:living-legend" }),
+        createCompletedGame(otherFinalState),
+      ],
+    };
+    const completed = gameReducer(stateWithRecords, {
+      state: finalState,
+      type: GameActionType.CompleteCareer,
+    });
+
+    expect(completed.gameState).toBe(finalState);
+    expect(completed.completedGames).toEqual([
+      createCompletedGame(finalState),
+      createCompletedGame(otherFinalState),
+    ]);
+    expect(
+      gameReducer(completed, {
+        state: finalState,
+        type: GameActionType.CompleteCareer,
+      }),
+    ).toBe(completed);
+  });
+
+  test("opens a completed game and restarts at the welcome screen", () => {
+    const finalState = createFinalState(createOutcomeState());
+    const game = createCompletedGame(finalState);
+    const state = { ...welcomeState, completedGames: [game] };
+    const opened = gameReducer(state, {
+      game,
+      type: GameActionType.OpenCompletedGame,
+    });
+    const restarted = gameReducer(opened, {
+      type: GameActionType.RestartGame,
+    });
+
+    expect(opened.gameState).toBe(finalState);
+    expect(restarted).toEqual({
+      completedGames: [game],
+      gameState: { screen: "welcome" },
+    });
+  });
+
+  test("rejects transitions from invalid screens and mismatched pilots", () => {
+    const outcomeState = createOutcomeState();
+    const wrongPilot = { ...pilot, id: "pilot:other" as const };
+
+    expect(
+      gameReducer(welcomeState, {
+        draft: { aspiration: null, faction: null, name: "" },
+        type: GameActionType.ChangePilotDraft,
+      }),
+    ).toBe(welcomeState);
+    expect(
+      gameReducer(outcomeState, {
+        eventId: eventCatalog.strayZoid.id,
+        history,
+        pilot: wrongPilot,
+        type: GameActionType.AdvanceYear,
+      }),
+    ).toBe(outcomeState);
+    expect(
+      gameReducer(welcomeState, { type: GameActionType.RevealOutcome }),
+    ).toBe(welcomeState);
+    expect(
+      gameReducer(welcomeState, { type: GameActionType.RestartGame }),
+    ).toBe(welcomeState);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace scattered game state updates with explicit reducer transitions.
- Define game actions as a closed discriminated union with centralized action constants.
- Reject invalid and repeated transitions through the current game state.
- Update the final state and completed career record atomically.
- Keep random generation, React, and storage outside the reducer.

## Tests

- `npm test -- --run`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`

Closes #19