### PR TITLE
Configure CI and release deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --registry=https://registry.npmjs.org/
+      - name: Check formatting
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Check types
+        run: npm run typecheck
+      - name: Run tests
+        run: npm run test:run
+      - name: Build
+        run: npm run build
+      - if: github.event_name == 'push'
+        name: Upload deployable build
+        uses: actions/upload-artifact@v4
+        with:
+          name: scars-of-steel-${{ github.sha }}
+          path: dist
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Publish release
+
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --registry=https://registry.npmjs.org/
+      - name: Check formatting
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Check types
+        run: npm run typecheck
+      - name: Run tests
+        run: npm run test:run
+      - name: Set build metadata
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
+      - name: Build
+        run: npm run build
+      - name: Upload release build
+        uses: actions/upload-artifact@v4
+        with:
+          name: scars-of-steel-${{ github.event.release.tag_name }}
+          path: dist
+          retention-days: 30
+      - name: Request website deployment
+        env:
+          GH_TOKEN: ${{ secrets.THECOREZI_WEB_DISPATCH_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          jq --null-input --arg tag "$RELEASE_VERSION" '{event_type: "scars-of-steel-release", client_payload: {tag: $tag}}' |
+            gh api --method POST repos/TheCoreZi/thecorezi-web/dispatches --input -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,19 @@ on:
     types:
       - released
 
-permissions:
-  contents: read
+concurrency:
+  cancel-in-progress: false
+  group: github-pages
 
 jobs:
-  publish:
-    name: Publish release
+  build:
+    name: Build release
+    permissions:
+      contents: read
+      pages: read
     runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.metadata.outputs.commit }}
     steps:
       - name: Check out release
         uses: actions/checkout@v6
@@ -33,23 +39,44 @@ jobs:
       - name: Run tests
         run: npm run test:run
       - name: Set build metadata
+        id: metadata
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "commit=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "COMMIT_SHA=$COMMIT_SHA" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
       - name: Build
         run: npm run build
-      - name: Upload release build
-        uses: actions/upload-artifact@v4
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          name: scars-of-steel-${{ github.event.release.tag_name }}
           path: dist
-          retention-days: 30
-      - name: Request website deployment
+
+  deploy:
+    name: Deploy release
+    needs: build
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+      - name: Check deployment
         env:
-          GH_TOKEN: ${{ secrets.THECOREZI_WEB_DISPATCH_TOKEN }}
+          RELEASE_COMMIT: ${{ needs.build.outputs.commit }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          jq --null-input --arg tag "$RELEASE_VERSION" '{event_type: "scars-of-steel-release", client_payload: {tag: $tag}}' |
-            gh api --method POST repos/TheCoreZi/thecorezi-web/dispatches --input -
+          SITE_URL="https://scars-of-steel.thecorezi.com"
+          curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 10 "$SITE_URL/" > /dev/null
+          curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 10 "$SITE_URL/build-info.json" --output "$RUNNER_TEMP/build-info.json"
+          jq --exit-status --arg commit "$RELEASE_COMMIT" --arg version "$RELEASE_VERSION" \
+            '.commit == $commit and .version == $version' "$RUNNER_TEMP/build-info.json"

--- a/README.md
+++ b/README.md
@@ -36,3 +36,42 @@ npm run build
 
 Run `npm test` to run tests in watch mode. Run `npm run lint:fix` or `npm run
 format` to fix files. Run `npm run preview` to serve the local build.
+
+## Continuous integration
+
+Pull requests and pushes to `master` install dependencies from the public npm
+registry. They check formatting, lint, types, tests, and the production build.
+A failed check stops the workflow. Builds from `master` are available as GitHub
+Actions artifacts for seven days.
+
+The npm cache stores downloaded packages only. Each workflow still uses `npm
+ci` to validate `package-lock.json` and create a clean dependency installation.
+
+## Releases
+
+Stable GitHub releases deploy to
+<https://thecorezi.com/scars-of-steel/>. Drafts and prereleases do not deploy.
+The release tag is the public version.
+
+The release workflow builds the tag and saves `dist` as a GitHub Actions
+artifact. It then requests a deployment from `TheCoreZi/thecorezi-web`. That
+site includes the latest stable game release at `/scars-of-steel/` and checks
+<https://thecorezi.com/scars-of-steel/build-info.json> after deployment. The
+metadata file has this format:
+
+```json
+{
+  "commit": "<full release commit SHA>",
+  "version": "<release tag>"
+}
+```
+
+Add a fine-grained token named `THECOREZI_WEB_DISPATCH_TOKEN` to the GitHub
+Actions secrets for this repository. Give the token access only to
+`TheCoreZi/thecorezi-web` and grant it write access to repository contents. The
+token sends the `repository_dispatch` event. It is not included in the source
+or build artifact.
+
+Disable GitHub Pages for this repository. `TheCoreZi/thecorezi-web` owns the
+Pages deployment and the `thecorezi.com` custom domain. Do not add a `CNAME`
+file here.

--- a/README.md
+++ b/README.md
@@ -50,14 +50,11 @@ ci` to validate `package-lock.json` and create a clean dependency installation.
 ## Releases
 
 Stable GitHub releases deploy to
-<https://thecorezi.com/scars-of-steel/>. Drafts and prereleases do not deploy.
-The release tag is the public version.
-
-The release workflow builds the tag and saves `dist` as a GitHub Actions
-artifact. It then requests a deployment from `TheCoreZi/thecorezi-web`. That
-site includes the latest stable game release at `/scars-of-steel/` and checks
-<https://thecorezi.com/scars-of-steel/build-info.json> after deployment. The
-metadata file has this format:
+<https://scars-of-steel.thecorezi.com/>. Drafts and prereleases do not deploy.
+The release tag is the public version. The release workflow builds the tag,
+deploys `dist` with GitHub Pages, and checks the public page after deployment.
+The metadata is available at
+<https://scars-of-steel.thecorezi.com/build-info.json> in this format:
 
 ```json
 {
@@ -66,12 +63,12 @@ metadata file has this format:
 }
 ```
 
-Add a fine-grained token named `THECOREZI_WEB_DISPATCH_TOKEN` to the GitHub
-Actions secrets for this repository. Give the token access only to
-`TheCoreZi/thecorezi-web` and grant it write access to repository contents. The
-token sends the `repository_dispatch` event. It is not included in the source
-or build artifact.
+In the repository Pages settings, select **GitHub Actions** as the source. Set
+the custom domain to `scars-of-steel.thecorezi.com`. Before you add the DNS
+record, add the custom domain to the repository settings. Then add a DNS CNAME
+record from `scars-of-steel` to `thecorezi.github.io`. Enable **Enforce HTTPS**
+after GitHub validates the DNS record.
 
-Disable GitHub Pages for this repository. `TheCoreZi/thecorezi-web` owns the
-Pages deployment and the `thecorezi.com` custom domain. Do not add a `CNAME`
-file here.
+The deployment uses `GITHUB_TOKEN` with native Pages permissions. It does not
+require repository secrets. Do not add a `CNAME` file because GitHub stores the
+custom domain in the Pages settings.

--- a/src/app/CareerStatusBar.tsx
+++ b/src/app/CareerStatusBar.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getAssetPath } from "../assets";
 import {
   getLifeStage,
   factionShortNameKeys,
@@ -15,8 +16,8 @@ import { translate } from "../i18n";
 import { RankInsignia } from "./RankInsignia";
 
 const factionLogoPaths = {
-  guylos: "/images/factions/guylos.png",
-  helic: "/images/factions/helic.png",
+  guylos: getAssetPath("images/factions/guylos.png"),
+  helic: getAssetPath("images/factions/helic.png"),
 } as const;
 const zoidFallbackIcon = "◇";
 

--- a/src/app/PilotCreationScreen.tsx
+++ b/src/app/PilotCreationScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getAssetPath } from "../assets";
 import {
   aspirationNameKeys,
   factionNameKeys,
@@ -26,8 +27,8 @@ const aspirationIconPaths = {
 } as const satisfies Record<Aspiration, string>;
 const factions = Object.keys(factionNameKeys) as Faction[];
 const factionLogoPaths = {
-  guylos: "/images/factions/guylos.png",
-  helic: "/images/factions/helic.png",
+  guylos: getAssetPath("images/factions/guylos.png"),
+  helic: getAssetPath("images/factions/helic.png"),
 } as const satisfies Record<Faction, string>;
 const pendingIcon = "⌁";
 const statNames: StatName[] = [

--- a/src/app/WelcomeScreen.tsx
+++ b/src/app/WelcomeScreen.tsx
@@ -1,6 +1,7 @@
 import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getAssetPath } from "../assets";
 import { militaryRankNameKeys, specialRankNameKeys } from "../domain/pilot";
 import { getRankInsignia } from "../domain/ranks";
 import { getTitleDefinition } from "../domain/titles";
@@ -71,7 +72,7 @@ export function WelcomeScreen({
             <img
               alt=""
               className="welcome__logo"
-              src="/images/brand/scars-of-steel-mark.png"
+              src={getAssetPath("images/brand/scars-of-steel-mark.png")}
             />
             <h1 id={titleId}>{t("welcome.title")}</h1>
           </div>

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,0 +1,3 @@
+export function getAssetPath(path: string): string {
+  return `${import.meta.env.BASE_URL}${path}`;
+}

--- a/src/domain/achievements.ts
+++ b/src/domain/achievements.ts
@@ -1,3 +1,4 @@
+import { getAssetPath } from "../assets";
 import type { AchievementId, TranslationKey } from "./types";
 
 export type AchievementIconId = "gavel" | "heart" | "wrench";
@@ -21,5 +22,7 @@ export const achievementNameKeys = {
 } as const satisfies Record<AchievementId, TranslationKey<"achievements">>;
 
 export function getAchievementIconPath(id: AchievementId): string {
-  return `/images/icons/achievements/${achievementIconIds[id]}.svg`;
+  return getAssetPath(
+    `images/icons/achievements/${achievementIconIds[id]}.svg`,
+  );
 }

--- a/src/domain/finalSummary.ts
+++ b/src/domain/finalSummary.ts
@@ -1,3 +1,5 @@
+import { getAssetPath } from "../assets";
+import { translate } from "../i18n";
 import {
   achievementDescriptionKeys,
   achievementNameKeys,
@@ -14,7 +16,6 @@ import { getRankInsignia, type RankInsigniaDefinition } from "./ranks";
 import { getTitleDefinition } from "./titles";
 import type { Faction, FinalGameState, StatName } from "./types";
 import { getZoid } from "./zoids";
-import { translate } from "../i18n";
 
 const finalFactionNameKeys = {
   guylos: "interface:finalScreen.factions.guylos",
@@ -102,7 +103,9 @@ export function createFinalSummary(state: FinalGameState): FinalSummary {
     battleLosses: state.history.battles.losses,
     battleWins: state.history.battles.wins,
     faction: state.pilot.faction,
-    factionImagePath: `/images/factions/${state.pilot.faction}.png`,
+    factionImagePath: getAssetPath(
+      `images/factions/${state.pilot.faction}.png`,
+    ),
     factionName: translate(factionNameKeys[state.pilot.faction]),
     factionTrust: state.pilot.career.factionTrust,
     fame: state.pilot.career.fame,

--- a/src/domain/ranks.ts
+++ b/src/domain/ranks.ts
@@ -1,3 +1,4 @@
+import { getAssetPath } from "../assets";
 import type { MilitaryRank } from "./types";
 
 export interface RankInsigniaDefinition {
@@ -5,15 +6,15 @@ export interface RankInsigniaDefinition {
 }
 
 export const rankInsigniaDefinitions = {
-  cadet: { imagePath: "/images/ranks/cadet.png" },
-  captain: { imagePath: "/images/ranks/captain.png" },
-  commander: { imagePath: "/images/ranks/commander.png" },
-  corporal: { imagePath: "/images/ranks/corporal.png" },
-  general: { imagePath: "/images/ranks/general.png" },
-  lieutenant: { imagePath: "/images/ranks/lieutenant.png" },
-  major: { imagePath: "/images/ranks/major.png" },
-  sergeant: { imagePath: "/images/ranks/sergeant.png" },
-  soldier: { imagePath: "/images/ranks/soldier.png" },
+  cadet: { imagePath: getAssetPath("images/ranks/cadet.png") },
+  captain: { imagePath: getAssetPath("images/ranks/captain.png") },
+  commander: { imagePath: getAssetPath("images/ranks/commander.png") },
+  corporal: { imagePath: getAssetPath("images/ranks/corporal.png") },
+  general: { imagePath: getAssetPath("images/ranks/general.png") },
+  lieutenant: { imagePath: getAssetPath("images/ranks/lieutenant.png") },
+  major: { imagePath: getAssetPath("images/ranks/major.png") },
+  sergeant: { imagePath: getAssetPath("images/ranks/sergeant.png") },
+  soldier: { imagePath: getAssetPath("images/ranks/soldier.png") },
 } as const satisfies Record<MilitaryRank, RankInsigniaDefinition>;
 
 export function getRankInsignia(rank: MilitaryRank): RankInsigniaDefinition {

--- a/src/domain/titles.ts
+++ b/src/domain/titles.ts
@@ -1,3 +1,4 @@
+import { getAssetPath } from "../assets";
 import type {
   CareerEndReason,
   CareerHistory,
@@ -33,7 +34,9 @@ function titleDefinition(
     canBeGranted,
     descriptionKey: `titles:${key}.description`,
     id,
-    iconPath: `/images/icons/titles/${id.slice("title:".length)}.png`,
+    iconPath: getAssetPath(
+      `images/icons/titles/${id.slice("title:".length)}.png`,
+    ),
     nameKey: `titles:${key}.name`,
   };
 }

--- a/src/domain/zoids.ts
+++ b/src/domain/zoids.ts
@@ -1,3 +1,4 @@
+import { getAssetPath } from "../assets";
 import {
   createBoundedValue,
   type Faction,
@@ -420,7 +421,7 @@ function createZoid({
     basePower: createBoundedValue(basePower),
     faction,
     id: `zoid:${id}`,
-    ...(image ? { imagePath: `/images/zoids/${image}.png` } : {}),
+    ...(image ? { imagePath: getAssetPath(`images/zoids/${image}.png`) } : {}),
     nameKey: `zoids:${name}.name` as TranslationKey<"zoids">,
   };
 }

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -205,7 +205,7 @@ describe("welcome screen", () => {
 
     const heading = await startPilotCreation();
     expect(heading).toBeInTheDocument();
-    expect(heading).toHaveFocus();
+    await waitFor(() => expect(heading).toHaveFocus());
     expect(document.querySelector(".welcome__damage")).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Language" })).toBeInTheDocument();
     expect(
@@ -452,7 +452,9 @@ describe("pilot creation", () => {
     expect(document.querySelectorAll(".decision-screen__prompt")).toHaveLength(
       8,
     );
-    expect(document.querySelector(".outcome-screen h1")).toHaveFocus();
+    await waitFor(() =>
+      expect(document.querySelector(".outcome-screen h1")).toHaveFocus(),
+    );
     expect(screen.getByLabelText("Career status")).toBeInTheDocument();
 
     const outcome = screen.getByRole("heading", { level: 1 }).textContent;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  base: "/scars-of-steel/",
+  base: "/",
   plugins: [react(), buildInfo()],
   test: {
     environment: "jsdom",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,33 @@
 import react from "@vitejs/plugin-react";
+import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [react()],
+  base: "/scars-of-steel/",
+  plugins: [react(), buildInfo()],
   test: {
     environment: "jsdom",
     setupFiles: "./src/tests/setup.ts",
   },
 });
+
+function buildInfo(): Plugin {
+  return {
+    name: "build-info",
+    generateBundle() {
+      const buildInfo = {
+        commit: process.env.COMMIT_SHA ?? "local",
+        version:
+          process.env.RELEASE_VERSION ??
+          process.env.npm_package_version ??
+          "development",
+      };
+
+      this.emitFile({
+        fileName: "build-info.json",
+        source: `${JSON.stringify(buildInfo, null, 2)}\n`,
+        type: "asset",
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- validate pull requests and `master` with clean npm installs, formatting, lint, types, tests, and builds
- deploy stable releases directly to GitHub Pages at `scars-of-steel.thecorezi.com`
- include the release tag and full commit SHA in `build-info.json`
- use root asset paths for the dedicated subdomain
- stabilize asynchronous focus assertions

## Validation

- `npm ci --registry=https://registry.npmjs.org/`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`: 222 tests passed
- production build with release metadata
- local HTTP checks for the page, image assets, and `build-info.json`

## GitHub configuration

1. Merge this PR.
2. In **Settings > Pages**, select **GitHub Actions** as the source.
3. Set the custom domain to `scars-of-steel.thecorezi.com`.
4. Add the DNS CNAME `scars-of-steel` pointing to `thecorezi.github.io`.
5. Enable **Enforce HTTPS** after GitHub validates DNS.
6. Publish a stable release.

No repository secret is required. Drafts and prereleases do not deploy.

Closes #12
