### PR TITLE
Update Pages actions for Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Build
         run: npm run build
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 


### PR DESCRIPTION
## Summary

- update `actions/configure-pages` to v6
- update `actions/upload-pages-artifact` to v5
- use the official Node.js 24-compatible action releases

## Validation

- `npm run format:check`
- workflow validation with `actionlint`

The release build reported Node.js 20 deprecation warnings from the previous action versions.
