### PR TITLE
Add fan project notice and asset credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Text adventure game about the career of a Zoids pilot.
 
+## Fan project notice
+
+Scars of Steel is an unofficial, non-profit fan game created by The Core Zi.
+This project is not affiliated with, sponsored by, or endorsed by TOMY Company,
+Ltd. or its partners. ZOIDS and its names, characters, images, and trademarks
+belong to TOMY Company, Ltd. and their respective owners.
+
+## Asset credits
+
+The following credits record the information that is currently available. An
+unknown license does not grant permission to reuse or redistribute an asset.
+
+| Assets                                                                                 | Source or creator                                                                                           | License status                                                                                                                                                          |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Some title icons in `public/images/icons/titles/`                                      | [CraftPix](https://craftpix.net/)                                                                           | Covered by the applicable [CraftPix file license](https://craftpix.net/file-licenses/). The product tier is not documented. Do not redistribute these files separately. |
+| Most Zoid sprites in `public/images/zoids/`                                            | The official Zoids Saga series for Game Boy Advance, collected through the internal `zoids-sleeper` project | The exact installment, original files, extraction details, and license are not documented.                                                                              |
+| Rank images in `public/images/ranks/`                                                  | Kenney Vleugels                                                                                             | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).                                                                                                          |
+| IBM Plex Mono, IBM Plex Sans, and Quantico fonts                                       | Fontsource packages                                                                                         | SIL Open Font License 1.1. See `public/fonts/OFL-1.1.txt`.                                                                                                              |
+| Faction emblems, brand images, achievement icons, remaining title icons, and UI images | The source is not documented.                                                                               | The license is not documented.                                                                                                                                          |
+
+## Code copyright
+
+The repository does not provide a general license to use, modify, or distribute
+its original code. Default copyright restrictions apply. Asset terms remain
+separate from the code copyright.
+
 ## Requirements
 
 - Node.js 20.19 or a later compatible version.

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -9,9 +9,15 @@ test("keeps every screen accessible and free of horizontal overflow", async ({
   await expect(
     page.getByRole("navigation", { name: "Application controls" }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("contentinfo", { name: "Fan project notice" }),
+  ).toBeAttached();
 
   await page.getByRole("button", { name: "Begin your career" }).click();
   await auditCurrentScreen(page, "pilot creation");
+  await expect(
+    page.getByRole("contentinfo", { name: "Fan project notice" }),
+  ).toBeAttached();
   await completePilotCreation(page);
   await auditCurrentScreen(page, "decision selection");
 

--- a/public/images/zoids/README.md
+++ b/public/images/zoids/README.md
@@ -1,5 +1,7 @@
 # Zoid sprites
 
-These PNG files come from the internal `zoids-sleeper` project. Each file maps to the same Zoid model in this project. Do not use a variant as a replacement for a missing model.
+These PNG files were collected through the internal `zoids-sleeper` project. Most sprites originate from the official Zoids Saga series for Game Boy Advance. The exact installment, original files, extraction details, and license are not documented.
+
+Each file maps to the same Zoid model in this project. Do not use a variant as a replacement for a missing model.
 
 The files keep their original dimensions and transparency. The interface uses a fallback when the catalog has no exact sprite.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ import {
   saveColorModePreference,
 } from "./colorModeStorage";
 import { DecisionScreen } from "./DecisionScreen";
+import { FanProjectFooter } from "./FanProjectFooter";
 import { FinalScreen } from "./FinalScreen";
 import { type CompletedGame, loadGameData, saveGameData } from "./gameStorage";
 import { type AppState, GameActionType, gameReducer } from "./gameReducer";
@@ -216,6 +217,7 @@ export function App() {
           />
         )}
       </ScreenTransition>
+      <FanProjectFooter />
     </div>
   );
 }

--- a/src/app/FanProjectFooter.tsx
+++ b/src/app/FanProjectFooter.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from "react-i18next";
+
+export function FanProjectFooter() {
+  const { t } = useTranslation("interface");
+
+  return (
+    <footer
+      aria-label={t("fanProjectFooter.label")}
+      className="fan-project-footer"
+    >
+      <p>{t("fanProjectFooter.creator")}</p>
+      <p>{t("fanProjectFooter.affiliation")}</p>
+      <p>{t("fanProjectFooter.rights")}</p>
+      <p>{t("fanProjectFooter.credits")}</p>
+    </footer>
+  );
+}

--- a/src/locales/en/interface.json
+++ b/src/locales/en/interface.json
@@ -81,6 +81,13 @@
     "guylos": "Guylos Empire",
     "helic": "Helic Republic"
   },
+  "fanProjectFooter": {
+    "affiliation": "This project is not affiliated with, sponsored by, or endorsed by TOMY Company, Ltd. or its partners.",
+    "credits": "Image credits: Kenney and CraftPix.",
+    "creator": "Scars of Steel is an unofficial, non-profit fan game created by The Core Zi.",
+    "label": "Fan project notice",
+    "rights": "ZOIDS and its names, characters, images, and trademarks belong to TOMY Company, Ltd. and their respective owners."
+  },
   "finalScreen": {
     "achievements": "Achievements",
     "age": "Age {{age}}",

--- a/src/locales/es/interface.json
+++ b/src/locales/es/interface.json
@@ -81,6 +81,13 @@
     "guylos": "Imperio de Guylos",
     "helic": "República de Helic"
   },
+  "fanProjectFooter": {
+    "affiliation": "Este proyecto no está afiliado, patrocinado ni respaldado por TOMY Company, Ltd. ni por sus socios.",
+    "credits": "Créditos de imágenes: Kenney y CraftPix.",
+    "creator": "Cicatrices de Acero es un juego de fans no oficial y sin ánimo de lucro creado por The Core Zi.",
+    "label": "Aviso de proyecto fan",
+    "rights": "ZOIDS y sus nombres, personajes, imágenes y marcas pertenecen a TOMY Company, Ltd. y a sus respectivos propietarios."
+  },
   "finalScreen": {
     "achievements": "Logros",
     "age": "Edad {{age}}",

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -317,6 +317,23 @@ p {
   --color-on-faction: #ffffff;
 }
 
+.fan-project-footer {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-4) clamp(var(--space-4), 4vw, var(--space-7));
+  border-top: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-background) 88%, transparent);
+  text-align: center;
+}
+
+.fan-project-footer p {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
 .screen {
   position: relative;
   z-index: 1;

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -91,6 +91,14 @@ describe("welcome screen", () => {
     expect(screen.getByText("1").nextElementSibling).toHaveTextContent(
       "war to decide",
     );
+    expect(
+      screen.getByRole("contentinfo", { name: "Fan project notice" }),
+    ).toHaveTextContent(
+      "Scars of Steel is an unofficial, non-profit fan game created by The Core Zi.",
+    );
+    expect(
+      screen.getByRole("contentinfo", { name: "Fan project notice" }),
+    ).toHaveTextContent("Image credits: Kenney and CraftPix.");
   });
 
   test("shows Spanish content", async () => {
@@ -126,6 +134,39 @@ describe("welcome screen", () => {
     expect(
       screen.getByRole("button", { name: "Inicia tu carrera" }),
     ).toBeInTheDocument();
+  });
+
+  test("shows the localized fan project notice on every screen", async () => {
+    const { rerender } = render(<App />);
+
+    expect(
+      screen.getByRole("contentinfo", { name: "Fan project notice" }),
+    ).toHaveTextContent(
+      "This project is not affiliated with, sponsored by, or endorsed by TOMY Company, Ltd. or its partners.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Begin your career" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Cadet enlistment form" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("contentinfo", { name: "Fan project notice" }),
+    ).toBeInTheDocument();
+
+    await i18n.changeLanguage("es");
+    rerender(<App />);
+
+    expect(
+      screen.getByRole("contentinfo", { name: "Aviso de proyecto fan" }),
+    ).toHaveTextContent(
+      "ZOIDS y sus nombres, personajes, imágenes y marcas pertenecen a TOMY Company, Ltd. y a sus respectivos propietarios.",
+    );
+    expect(
+      screen.getByRole("contentinfo", { name: "Aviso de proyecto fan" }),
+    ).toHaveTextContent("Créditos de imágenes: Kenney y CraftPix.");
   });
 
   test("shows compact service records without visible Zoid names", () => {


### PR DESCRIPTION
## Summary

- Add a bilingual fan project notice to every application screen.
- Credit TOMY, Kenney, and CraftPix.
- Document known asset sources and license status.
- Record that most Zoid sprites originate from the Zoids Saga series.
- Add localization, accessibility, and persistence tests for the footer.

## Known limitation

- The exact Zoids Saga installment, extraction details, and sprite license are not documented.

## Testing

- `npm run verify`
- `npm run verify:browser`

Related to #25
